### PR TITLE
Pagrubel devops context switching

### DIFF
--- a/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
+++ b/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
@@ -3,7 +3,7 @@
 
 <!-- deck text start -->
 The article *Addressing the Detrimental Effects of Context Switching with
-DevOps* explores the adverse effects on productivity when software development team members are required to switch between projects, and outlines some devop practices to mitigate those effects.
+DevOps* explores the adverse effects on productivity when software development team members are required to switch between projects, and outlines some DevOps practices mitigating those effects.
 <!-- deck text end -->
 
 #### Contributed by [Patricia  Grubel](https://github.com/pagrubel "Patricia Grubel Github Profile")
@@ -27,7 +27,7 @@ project, but that is not usually the case, nor is it very practical. The
 article has some helpful ideas about improving the process when context
 switching does occur.
 
-Some devop practices to mitigate the overhead of context switching outlined in
+Some DevOps practices to mitigate the overhead of context switching outlined in
 the article are:
 
  - Using Continuous Integration (CI)
@@ -37,7 +37,7 @@ the article are:
  - Monitoring issue trackers for assignments
  - Limiting the number of projects for an individual
 
-As a side note, another resource for practical team devop practices is the book *Implementing
+As a side note, another resource for practical team DevOps practices is the book *Implementing
 Lean Software Development*. The book also contains information on the impact of
 task switching and the resulting degraded productivity.
 

--- a/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
+++ b/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
@@ -13,7 +13,7 @@ Resource information | Details
 :--- | :---
 Article title  | [Addressing the Detrimental Effects of Context Switching with DevOps](https://insights.sei.cmu.edu/devops/2015/03/addressing-the-detrimental-effects-of-context-switching-with-devops.html)
 Author | Todd Waits
-Focus | Improving devops practices to mitigate the effects of developer context switching.
+Focus | Improving team productivity
 
 In *Addressing the Detrimental Effects of Context Switching with Deveops*, Todd
 Waits makes the case that when a software developer switches from one project to
@@ -49,9 +49,10 @@ Mary Poppendieck and Tom Poppendieck, *Implementing Lean Software Development*, 
 <!---
 Publish: 
 RSS update: 2020-06-26
-Categories: Skills 
+Categories: Skills
 Topics: Strategies for More Effective Teams, Software Engineering, Personal Productivity
 Level: 
 Prerequisites: defaults
 Aggregate: none
+Review: LA-UR-20-XXXXX
 --->

--- a/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
+++ b/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
@@ -15,7 +15,7 @@ Article title  | [Addressing the Detrimental Effects of Context Switching with D
 Author | Todd Waits
 Focus | Improving team productivity
 
-In *Addressing the Detrimental Effects of Context Switching with Deveops*, Todd
+In *[Addressing the Detrimental Effects of Context Switching with DevOps](https://insights.sei.cmu.edu/devops/2015/03/addressing-the-detrimental-effects-of-context-switching-with-devops.html)*, Todd
 Waits makes the case that when a software developer switches from one project to
 another an overhead of approximately 20 percent is incurred to perform the task.
 The overhead is due to the amount of information a developer keeps in their
@@ -37,7 +37,7 @@ the article are:
  - Monitoring issue trackers for assignments
  - Limiting the number of projects for an individual
 
-Another resource for practical team devop practices is the book *Implementing
+As a side note, another resource for practical team devop practices is the book *Implementing
 Lean Software Development*. The book also contains information on the impact of
 task switching and the resulting degraded productivity.
 

--- a/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
+++ b/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
@@ -7,7 +7,7 @@ DevOps* explores the adverse effects on productivity when software development t
 <!-- deck text end -->
 
 #### Contributed by [Patricia  Grubel](https://github.com/pagrubel "Patricia Grubel Github Profile")
-#### Publication date: August 31, 2020
+#### Publication date: August 27, 2020
 
 Resource information | Details
 :--- | :---
@@ -48,12 +48,8 @@ Addison Wesley, 2007
 
 
 <!---
-Publish: 
-RSS update: 2020-06-26
+Publish: yes
+RSS update: 2020-08-27
 Categories: Skills
 Topics: Strategies for More Effective Teams, Software Engineering, Personal Productivity
-Level: 
-Prerequisites: defaults
-Aggregate: none
-Review: LA-UR-20-XXXXX
 --->

--- a/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
+++ b/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
@@ -42,7 +42,8 @@ Lean Software Development*. The book also contains information on the impact of
 task switching and the resulting degraded productivity.
 
 ### Additional References
-Mary Poppendieck and Tom Poppendieck, *Implementing Lean Software Development*, 2007
+Mary Poppendieck and Tom Poppendieck, *Implementing Lean Software Development*,
+Addison Wesley, 2007
 
 
 

--- a/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
+++ b/CuratedContent/DetrimentalEffectsContextSwitchingDevOps.md
@@ -1,0 +1,57 @@
+
+# A Look at Detrimental Effects of Context Switching with DevOps
+
+<!-- deck text start -->
+The article *Addressing the Detrimental Effects of Context Switching with
+DevOps* explores the adverse effects on productivity when software development team members are required to switch between projects, and outlines some devop practices to mitigate those effects.
+<!-- deck text end -->
+
+#### Contributed by [Patricia  Grubel](https://github.com/pagrubel "Patricia Grubel Github Profile")
+#### Publication date: August 31, 2020
+
+Resource information | Details
+:--- | :---
+Article title  | [Addressing the Detrimental Effects of Context Switching with DevOps](https://insights.sei.cmu.edu/devops/2015/03/addressing-the-detrimental-effects-of-context-switching-with-devops.html)
+Author | Todd Waits
+Focus | Improving devops practices to mitigate the effects of developer context switching.
+
+In *Addressing the Detrimental Effects of Context Switching with Deveops*, Todd
+Waits makes the case that when a software developer switches from one project to
+another an overhead of approximately 20 percent is incurred to perform the task.
+The overhead is due to the amount of information a developer keeps in their
+brain in order to perform development tasks. The article presents data that shows that the
+overhead commpounds with an increase in the number of projects, making the
+developer even less productive. It might be ideal for software developers to
+devote 100 percent of their time on one project or even one task in that
+project, but that is not usually the case, nor is it very practical. The
+article has some helpful ideas about improving the process when context
+switching does occur.
+
+Some devop practices to mitigate the overhead of context switching outlined in
+the article are:
+
+ - Using Continuous Integration (CI)
+ - Automatically assigning code reviews
+ - Regular communication
+ - Daily stand up meetings
+ - Monitoring issue trackers for assignments
+ - Limiting the number of projects for an individual
+
+Another resource for practical team devop practices is the book *Implementing
+Lean Software Development*. The book also contains information on the impact of
+task switching and the resulting degraded productivity.
+
+### Additional References
+Mary Poppendieck and Tom Poppendieck, *Implementing Lean Software Development*, 2007
+
+
+
+<!---
+Publish: 
+RSS update: 2020-06-26
+Categories: Skills 
+Topics: Strategies for More Effective Teams, Software Engineering, Personal Productivity
+Level: 
+Prerequisites: defaults
+Aggregate: none
+--->


### PR DESCRIPTION
PR for issue #444
Author: Pat
EB member: Ross

This was suggested by Will Mclendon at SNL:

Addressing the Detrimental Effects of Context Switching with DevOps
The problem with context switching is addressed by Kanban and is also well described in the book:

Poppendieck, Mary and Tom. Implementing Lean Software Development. Addison Wesley, 2007