### PR TITLE
Content bug fix: https://bssw.io/items/a-collection-of-resources-for-sustaining-open-source-software

### DIFF
--- a/CuratedContent/OSSSustainabilityResources.md
+++ b/CuratedContent/OSSSustainabilityResources.md
@@ -58,7 +58,7 @@ Web links | [Request for Commits Podcast](https://changelog.com/rfc)
 
 Resource information | Details 
 :--- | :--- 
-Podcast title  | Name of the tutorial without hyperlink 
+Podcast title  | RCE Podcast
 Presenters | Brock Palen and Jeff Sqyres
 Web links | [RCE Podcast](http://www.rce-cast.com/)
 


### PR DESCRIPTION
From issue #590 
Table entry that said "Name of the tutorial without hyperlink" is fixed to "RCE Podcast"