### PR TITLE
Changed formatting re: contributor

### DIFF
--- a/CuratedContent/ProducingWebinarSeries.md
+++ b/CuratedContent/ProducingWebinarSeries.md
@@ -5,7 +5,7 @@ In this article we introduce the *machinery* behind the
 HPC Best Practices Webinar Series.
 <!-- deck text end --> 
 
-### Contributed by [Osni Marques](http://github.com/oamarques)
+#### Contributed by [Osni Marques](http://github.com/oamarques)
 
 #### Publication date: July 5, 2020
 


### PR DESCRIPTION
"Contributed by" should now have the correct coding to show up in the deck text instead of being displayed in the article.