### PR TITLE
Tools needed to convert images to local repo refs (#703, #738)

### DIFF
--- a/utils/convert_images_ref_to_rel_path.py
+++ b/utils/convert_images_ref_to_rel_path.py
@@ -32,9 +32,10 @@ def getMdFilePathFromCmndLine():
   return mdFilePath
 
 
-g_external_images_repo_str = \
-  "https://github.com/betterscientificsoftware/images/raw/master/"
-
+g_external_images_repo_str_list = [
+  "https://github.com/betterscientificsoftware/images/raw/master/",
+  "https://github.com/betterscientificsoftware/images/blob/master/",
+  ]
 
 def getRelImagesRefStr(dirDepth):
   relImagesRefStr = "images/"
@@ -55,7 +56,9 @@ def replaceImagesRef(mdFilePath):
   # Do replacements for the images ref
   fileContentsOutList = []
   for line in fileContentsInList:
-    newLine = line.replace(g_external_images_repo_str, localImagesRef)
+    newLine = line
+    for g_external_images_repo_str in g_external_images_repo_str_list:
+      newLine = newLine.replace(g_external_images_repo_str, localImagesRef)
     if newLine != line:
       print("Replacing line: "+line)
       print("With line     : "+newLine)

--- a/utils/convert_images_ref_to_rel_path.py
+++ b/utils/convert_images_ref_to_rel_path.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+#
+# Run as:
+#
+#   cd bssw.io/
+#   ./utils/convert_images_ref_to_rel_path.py <md-file-path>
+#
+# to replace:
+#
+#   https://github.com/betterscientificsoftware/images/raw/master/
+#
+# with the proper local reference to:
+#
+#   ../../images/
+#
+# in an input *.md file <md-file-path> where the relative path depends on the
+# local directory path of the *.md file.
+#
+
+import sys
+import os
+
+
+def getMdFilePathFromCmndLine():
+  if len(sys.argv) != 2:
+    print("Error, must be passed local path to *.md file!")
+    sys.exit(1)
+  mdFilePath = sys.argv[1]
+  if not os.path.exists(mdFilePath):
+    print("Error, input '"+mdFilePath+"' is not a valid file path!")
+    sys.exit(1)
+  return mdFilePath
+
+
+g_external_images_repo_str = \
+  "https://github.com/betterscientificsoftware/images/raw/master/"
+
+
+def getRelImagesRefStr(dirDepth):
+  relImagesRefStr = "images/"
+  for i in range(dirDepth):
+    relImagesRefStr = "../" + relImagesRefStr
+  return relImagesRefStr
+
+ 
+def replaceImagesRef(mdFilePath):
+  # Find depth in local file path and local images ref
+  dirDepth = len(mdFilePath.split("/")) - 1
+  localImagesRef = getRelImagesRefStr(dirDepth)
+  #print("dirDepth = "+str(dirDepth))
+  #print("localImagesRef = "+str(localImagesRef))
+  # Get the contents of the file on input
+  with open(mdFilePath, 'r') as fileHandle:
+    fileContentsInList = fileHandle.read().split("\n")
+  # Do replacements for the images ref
+  fileContentsOutList = []
+  for line in fileContentsInList:
+    newLine = line.replace(g_external_images_repo_str, localImagesRef)
+    if newLine != line:
+      print("Replacing line: "+line)
+      print("With line     : "+newLine)
+    fileContentsOutList.append(newLine)
+  # Write the output file (if it changed)
+  if fileContentsOutList != fileContentsInList:
+    print("Writing updated output file '"+mdFilePath+"'") 
+    with open(mdFilePath, 'w') as fileHandle:
+      fileHandle.write("\n".join(fileContentsOutList))
+
+
+#
+# Main
+#
+
+if __name__ == '__main__':
+  mdFilePath = getMdFilePathFromCmndLine()
+  print("Replacing images reference in file '"+mdFilePath+"'")
+  replaceImagesRef(mdFilePath)

--- a/utils/convert_images_ref_to_rel_path_all.sh
+++ b/utils/convert_images_ref_to_rel_path_all.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Run as:
+#
+#   cd bssw.io/
+#   ./utils/convert_images_ref_to_rel_path_all.sh
+#
+# to update the images refs to relative paths in this repo for all of *.md
+# files the bssw.io repo.
+#
+
+find Articles CuratedContent Events Site -name "*.md" \
+  -exec ./utils/convert_images_ref_to_rel_path.py {} \;
+
+# NOTE: We don't want to replace any paths in the bssw.io/docs/ directory
+# because those are for a github pages site and if they reference any images,
+# those will point into bssw.io/docs/images/ and **not** into bssw.io/images/!


### PR DESCRIPTION
CC: @bernhold, @prwolfe

Addresses #703, #738

These are the scripts needed to convert the bssw.io repo references from the external github images repo to the local directory reference.  To run this for the entire repo, just checkout this branch and run:

```
$ cd bssw.io/
$ ./utils/convert_images_ref_to_rel_path_all.sh
``` 

I ran this on the entire bssw.io repo on 'master' as:

```
$ time ./utils/convert_images_ref_to_rel_path_all.sh &> convert_images_ref_to_rel_path_all.out.txt

real    0m41.297s
user    0m7.258s
sys     0m24.750s
```

(on my slow Cygwin Windows 10 machine) and it produced the output [convert_images_ref_to_rel_path_all.out.txt](https://github.com/betterscientificsoftware/bssw.io/files/6201492/convert_images_ref_to_rel_path_all.out.txt) and the changed files shown by:

```
$ git status | grep "modified:" &> git_status_modified_files.txt
```

showing the output [git_status_modified_files.txt](https://github.com/betterscientificsoftware/bssw.io/files/6201495/git_status_modified_files.txt).

You can see what the updated files looks like in PR https://github.com/bartlettroscoe/bssw.io/pull/4 with files shown at:

* https://github.com/bartlettroscoe/bssw.io/tree/703-convert-images-trial/

For example, you can see that GitHub is displaying the images correctly for the article:

* https://github.com/bartlettroscoe/bssw.io/blob/703-convert-images-trial/Articles/Blog/ApolloGuidanceComputerPart1.md

which has several images.

Here are the files that are not converted by this script:

```
$ find . -name "*.md" -exec grep -l "github[.]com/betterscientificsoftware/images/" {} \;
./docs/pages/bssw/bssw_content_highlighting.md
./docs/pages/bssw/bssw_pr_preview_branch.md
./docs/pages/bssw/bssw_styling_common.md
./docs/pages/bssw/bssw_styling_curated.md
./docs/pages/bssw/bssw_styling_originalarticles.md
./images/README.md
```

Someone needs to update the file `images/README.md` to make sense (see PR #754).
