### PR TITLE
Only merge PR to 'preview' branch when 'preview' label is set and provide PR template with checklist (#695, #702, #744, #750, #330)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,9 @@ Provide a general summary of your changes in the title above.
 
 Fill in the below **Description** section with minimal text describing the changes/new contributions in this PR and replace `<...>` as appropriate.
 
-Remove the beginning `<!--` and ending `-->` comment markers for the correct **Checklist** for this PR and delete the other Checklists.
+Remove the beginning `<!--` and ending `-->` comment markers for the correct **checklist** to be used for this PR and delete the other checklist.  (The checklist items for bssw.io site contributions are shown by default.  The checklist for internal files not displayed in the bssw.io site is given below that.)
+
+Any checklist items that don't apply can be striked out by adding `~~` to the beginning and end of the checklist item as `* ~~[] <checklist-item>~~`.  Also, remove the strikeout markers `~~` for the [wikize_refs.py] checklist items if using formal citations for bssw.io contributions.
 
 
 # Description
@@ -20,71 +22,45 @@ Addresses issue #`<issue-id>`
 `<Other minimal information about the PR.>`
 
 
-## Checklist for files displayed on bssw.io site
+## PR checklist for files displayed on bssw.io site
 
-*Click "Write" above and remove comment markers to see checklist items*
-
-<!-- REMOVE THIS COMMENT MARKER IF USING BELOW CHECKLIST
 * [ ] `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
 * [ ] Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
 * [ ] Assign this PR to the EB member `<eb-member-id>`.
 * [ ] Assign this PR to the author of the PR `<pr-author-id>`.
 * [ ] Add label `content: <content-type>` for the type of contribution.
-* [ ] Add to Project `Content Development` (see [content development]).
+* [ ] Add to Project `Content Development` (see [Content Development]).
 * [ ] Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
 * [ ] Add one or more Reviewers.
 * [ ] Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
-* [ ] Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
+* ~~[ ] Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py])~~.
 * [ ] Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
+* [ ] Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
 * [ ] Make any final changes to the PR based on feedback.
+* ~~[ ] Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py]).~~
 * [ ] Rebuild [preview] site and re-confirm content looks correct.
 * [ ] Ensure at least one reviewer signs off on the final changes.
 * [ ] Change meta-data to `Publish: yes` and commit if fully ready to publish.
-* [ ] Move the PR to "Ready to Publish" in [content development].
+* [ ] Move the PR to "Ready to Publish" in [Content Development].
 * [ ] Assign to one of the site maintainers to carry out final publication steps.
 * [ ] Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
-* [ ] Merge PR. Should automatically move to "Done" in [content development].
+* [ ] Merge PR. Should automatically move to "Done" in [Content Development].
 * [ ] Verify new new contribution shows up on [bssw.io] as expected.
-REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
+
+NOTE: Optional checklist items can be striked out with adding `~~` to beginning and end of the checklist item as `* ~~[ ] <checklist-item>~~`.
+
+<!-- NOTE: Remove above checklist if using the below checklist for internal files. -->
+
+<!-- NOTE: Remove below checklist if using the above checklist for  bssw.io files. -->
 
 
-## Checklist for files displayed on bssw.io site using formal citations
+## PR checklist for (internal) files not displayed on bssw.io site
 
-*Click "Write" above and remove comment markers to see checklist items*
+*Click "Write" above and remove comment markers to see below checklist items*
 
 <!-- REMOVE THIS COMMENT MARKER IF USING BELOW CHECKLIST
-* [ ] `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
-* [ ] Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
-* [ ] Assign this PR to the EB member `<eb-member-id>`.
-* [ ] Assign this PR to the author of the PR `<pr-author-id>`.
-* [ ] Add label `content: <content-type>` for the type of contribution.
-* [ ] Add to Project `Content Development` (see [content development]).
-* [ ] Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
-* [ ] Add one or more Reviewers.
-* [ ] Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
-* [ ] Ensure `wikize_refs.py -i <base>.md` is run and commit (see [wikize_refs.py]).
-* [ ] Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
-* [ ] Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
-* [ ] Make any final changes to the PR based on feedback.
-* [ ] Ensure `wikize_refs.py -i <base>.md` is run and commit.
-* [ ] Rebuild [preview] site and re-confirm content looks correct.
-* [ ] Ensure at least one reviewer signs off on the final changes.
-* [ ] Change meta-data to `Publish: yes` and commit if fully ready to publish.
-* [ ] Move the PR to "Ready to Publish" in [content development].
-* [ ] Assign to one of the site maintainers to carry out final publication steps.
-* [ ] Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
-* [ ] Merge PR. Should automatically move to "Done" in [content development].
-* [ ] Verify new new contribution shows up on [bssw.io] as expected.
-REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
-
-
-## Checklist for (internal) files not displayed on bssw.io site
-
-*Click "Write" above and remove comment markers to see checklist items*
-
-<!-- REMOVE THIS COMMENT MARKER IF USING BELOW CHECKLIST
-* [ ] Set list of Reviewers (please at least one).
-* [ ] Add to Project `BSSw Internal`.
+* [ ] Set list of Reviewers (at least one).
+* [ ] Add to Project [BSSw Internal].
 * [ ] View the modified `*.md` files as rendered in GitHub.
 * [ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.
 * [ ] Watch for PR check failures.
@@ -94,10 +70,11 @@ REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
 REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
 
 
-<!-- Standard links below, leave these! -->
+<!-- Standard links below, leave these this section! -->
 
 [preview]: https://preview.bssw.io
 [bssw.io]: https://bssw.io
-[content development]: https://github.com/betterscientificsoftware/bssw.io/projects/3?
+[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
+[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
 [meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
 [wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,9 +40,11 @@ Addresses issue #`<issue-id>`
 * [ ] Rebuild [preview] site and re-confirm content looks correct.
 * [ ] Ensure at least one reviewer signs off on the final changes.
 * [ ] Change meta-data to `Publish: yes` and commit if fully ready to publish.
-* [ ] Merge this PR (but keep PR in "Item Review" in [content development]).
-* [ ] Verify new contribution shows up on [bssw.io] as expected.
-* [ ] Move this PR from "Item Review" to "Done".
+* [ ] Move the PR to "Ready to Publish" in [content development].
+* [ ] Assign to one of the site maintainers to carry out final publication steps.
+* [ ] Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
+* [ ] Merge PR. Should automatically move to "Done" in [content development].
+* [ ] Verify new new contribution shows up on [bssw.io] as expected.
 REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
 
 
@@ -68,9 +70,11 @@ REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
 * [ ] Rebuild [preview] site and re-confirm content looks correct.
 * [ ] Ensure at least one reviewer signs off on the final changes.
 * [ ] Change meta-data to `Publish: yes` and commit if fully ready to publish.
-* [ ] Merge this PR (but keep PR in "Item Review" in [content development]).
-* [ ] Verify new contribution shows up on [bssw.io] as expected.
-* [ ] Move this PR from "Item Review" to "Done".
+* [ ] Move the PR to "Ready to Publish" in [content development].
+* [ ] Assign to one of the site maintainers to carry out final publication steps.
+* [ ] Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
+* [ ] Merge PR. Should automatically move to "Done" in [content development].
+* [ ] Verify new new contribution shows up on [bssw.io] as expected.
 REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,99 @@
+# Instructions (DELETE THIS SECTION)
+
+To view these instructions, please hit the **Preview** tab (above left). After you have read all of these instructions, delete them entirely from the body of this issue before entering your submission.
+
+Be sure to select `master` as the `base` branch above as the target for this PR.
+
+Provide a general summary of your changes in the title above.
+
+Fill in the below **Description** section with minimal text describing the changes/new contributions in this PR and replace `<...>` as appropriate.
+
+Remove the beginning `<!--` and ending `-->` comment markers for the correct **Checklist** for this PR and delete the other Checklists.
+
+
+# Description
+
+EB Member: @`<eb-member-id>`
+
+Addresses issue #`<issue-id>`
+
+`<Other minimal information about the PR.>`
+
+
+## Checklist for files displayed on bssw.io site
+
+*Click "Write" above and remove comment markers to see checklist items*
+
+<!-- REMOVE THIS COMMENT MARKER IF USING BELOW CHECKLIST
+* [ ] `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
+* [ ] Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
+* [ ] Assign this PR to the EB member `<eb-member-id>`.
+* [ ] Assign this PR to the author of the PR `<pr-author-id>`.
+* [ ] Add label `content: <content-type>` for the type of contribution.
+* [ ] Add to Project `Content Development` (see [content development]).
+* [ ] Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
+* [ ] Add one or more Reviewers.
+* [ ] Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
+* [ ] Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
+* [ ] Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
+* [ ] Make any final changes to the PR based on feedback.
+* [ ] Rebuild [preview] site and re-confirm content looks correct.
+* [ ] Ensure at least one reviewer signs off on the final changes.
+* [ ] Change meta-data to `Publish: yes` and commit if fully ready to publish.
+* [ ] Merge this PR (but keep PR in "Item Review" in [content development]).
+* [ ] Verify new contribution shows up on [bssw.io] as expected.
+* [ ] Move this PR from "Item Review" to "Done".
+REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
+
+
+## Checklist for files displayed on bssw.io site using formal citations
+
+*Click "Write" above and remove comment markers to see checklist items*
+
+<!-- REMOVE THIS COMMENT MARKER IF USING BELOW CHECKLIST
+* [ ] `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
+* [ ] Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
+* [ ] Assign this PR to the EB member `<eb-member-id>`.
+* [ ] Assign this PR to the author of the PR `<pr-author-id>`.
+* [ ] Add label `content: <content-type>` for the type of contribution.
+* [ ] Add to Project `Content Development` (see [content development]).
+* [ ] Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
+* [ ] Add one or more Reviewers.
+* [ ] Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
+* [ ] Ensure `wikize_refs.py -i <base>.md` is run and commit (see [wikize_refs.py]).
+* [ ] Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
+* [ ] Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
+* [ ] Make any final changes to the PR based on feedback.
+* [ ] Ensure `wikize_refs.py -i <base>.md` is run and commit.
+* [ ] Rebuild [preview] site and re-confirm content looks correct.
+* [ ] Ensure at least one reviewer signs off on the final changes.
+* [ ] Change meta-data to `Publish: yes` and commit if fully ready to publish.
+* [ ] Merge this PR (but keep PR in "Item Review" in [content development]).
+* [ ] Verify new contribution shows up on [bssw.io] as expected.
+* [ ] Move this PR from "Item Review" to "Done".
+REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
+
+
+## Checklist for (internal) files not displayed on bssw.io site
+
+*Click "Write" above and remove comment markers to see checklist items*
+
+<!-- REMOVE THIS COMMENT MARKER IF USING BELOW CHECKLIST
+* [ ] Set list of Reviewers (please at least one).
+* [ ] Add to Project `BSSw Internal`.
+* [ ] View the modified `*.md` files as rendered in GitHub.
+* [ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.
+* [ ] Watch for PR check failures.
+* [ ] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
+* [ ] Ensure at least one reviewer signs off on the changes.
+* [ ] Once reviewer has approved and PR check pass, then merge the PR.
+REMOVE THIS COMMENT MARKER IF USING ABOVE CHECKLIST -->
+
+
+<!-- Standard links below, leave these! -->
+
+[preview]: https://preview.bssw.io
+[bssw.io]: https://bssw.io
+[content development]: https://github.com/betterscientificsoftware/bssw.io/projects/3?
+[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
+[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -9,12 +9,13 @@ Format:
         - description
 
 # Workflows in use
+
 * merge-master-to-preview.yml (Sync master to preview)
     - trigger: push to master branch
     - job: sync-preview
         - Merges from master into preview branch.
 * merge-pr-to-preview.yml (Sync pull request to preview)
-    - trigger: pull request [opened, synchronized] on master branch
+    - trigger: pull request [opened, synchronized, labeled] (only if has 'preview' label)
     - job: sync-pull-request
         - Merges PR into preview branch
 * no-prs-on-preview.yml (Reject pull requests on preview branch)

--- a/.github/workflows/merge-pr-to-preview.yml
+++ b/.github/workflows/merge-pr-to-preview.yml
@@ -1,14 +1,17 @@
 name: Sync pull request to preview
 on:
   pull_request_target:
-    types: [opened, synchronize]
+    types: [opened, synchronize, labeled]
     branches:
       - master
 jobs:
   sync-pull-request:
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          ref: 'preview'  # Not default 'master' branch
       - name: Merge pr -> preview
         uses: devmasx/merge-branch@v1.3.0
         with:
@@ -16,3 +19,9 @@ jobs:
           head_to_merge: ${{ github.event.pull_request.head.sha }}
           target_branch: preview
           github_token: ${{ secrets.GITHUB_TOKEN }}
+
+# NOTE: Above, we use the 'if' statement for looking for the 'preview' label
+# and then only run the job if that label is found in the PR.  I tried using
+# the setting {label_name: 'preview'} for the `devmasx/merge-branch` action
+# above but it seemed to ignore it and try to merge the PR branch to 'preview'
+# anyway.


### PR DESCRIPTION
# Description

EB Member: @bernhold

Addresses issues #695, #702, #744, #750, #330

This PR does two things.  First, it extends the `merge-pr-to-preview.yml` workflow to only merge PR branches to the 'preview' branch if the PR contains the `preview` label.   Second, it adds a PR template file for three types of PRs:

* a) bssw.io content
* b) bssw.io content with formal citations (using `wikize_refs.py`)
*c) non-bssw.io content

In installed this updated `merge-pr-to-preview.yml` workflow  to [my fork's](https://github.com/bartlettroscoe/bssw.io) 'master' branch and did some very detailed and carefully documented manual tests (see below). 

To try this out yourself, just create a branch off of the 'master' branch of [my fork](https://github.com/bartlettroscoe/bssw.io) and post a PR to that fork's 'master' branch and you will see the template in use.  Also, you can set the `preview` label and watch the PR's commits get merged (or not get merged) based on if that label is set or not.


## How was this tested?

I used the installation of these files in  [my fork's](https://github.com/bartlettroscoe/bssw.io) 'master' branch to test this out.  I created two PRs in my fork and pushed commits and set labels, etc., to test out the various use cases and carefully documented the test results.  The two test PRs were/are:

* https://github.com/bartlettroscoe/bssw.io/pull/7: **Add mention of 'preview' label on PR (#744, #330)**:  This is a PR changing files under the `docs/` directory not viewed on [bssw.io] and therefore no reason to set the `preview` label.  (This PR is never merged to the 'preview' branch in my fork).

* https://github.com/bartlettroscoe/bssw.io/pull/8: **Fix some whitespace**: This PR changes an `*.md` file that is viewed on the bssw.io site and I several events where I set or unset the `preview` label.

The tests I performed were:

* Reset 'rab-github/preview' back to 'rab-github/master' and force push (so 'preview' starts out idential to 'master') **[Done]**
* Test PR that does not get merged to 'preview' branch: **[Passed]**
  - Create new PR for branch '744-rab-preview-label-eb-docs-1' using the non-bssw.io template and don't set the 'preview' label (verfy that merge to 'preview' is skipped) **[Passed]**
  - Push another commit (verify that merge to 'preview' is skipped) **[Passed]**
* Test PR that should merge to 'preview' branch: **[Passed]**
  - Create new branch 'change-bssw-io-content-preview-label-1' with one commit **[Done]** 
  - Create new PR for branch 'change-bssw-io-content-preview-label-1' using bssw.io (verify job is skipped)  **[Passed]**
  - Add the label 'enhancement' (verify job is skipped) **[Passed]**
  - Add the 'preview' label (verify job is run merged to 'preview' branch) **[Passed]**
  - Remove the 'preview' label (verify no action occurs) **[Done]**
  - Push another commit to 'change-bssw-io-content-preview-label-1' (verify job is skipped because 'preview' label is not set) **[Passed]**
  - Add the 'preview' label (verify job is run merged to 'preview' branch) **[Passed]**
  - Push another commit to 'change-bssw-io-content-preview-label' (verify job is run merged to 'preview' branch) **[Passed]**

These manual tests are documented in more detail below 

<details>

<summary><b>Detailed manual test cases and evidence</b> (Click to expand)</summary>

.

**A) Create PR for files that will not to be merged to 'preview'**

I pushed the branch [744-rab-preview-label-eb-docs-1](https://github.com/bartlettroscoe/bssw.io/tree/744-rab-preview-label-eb-docs-1) that has the commit:

```
49beb658 "Add mention of 'preview' label on PR (#744, #330)"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Mar 25 17:05:37 2021 -0400 (26 hours ago)

M       docs/pages/bssw/bssw_content_publishing.md
```

This mimics a change to files that will not be published in the bssw.io site so there is no reason to merge this branch to the 'preview' branch to be viewed on the preview.bssw.io site.

From that branch I create the following PR against the 'master' branch of my repo using the custom template:

* https://github.com/bartlettroscoe/bssw.io/pull/7

The creation of the PR triggered the `merge-pr-to-preview.yml` workflow which ran a skipped job:

* https://github.com/bartlettroscoe/bssw.io/pull/7/checks?check_run_id=2206155376

So GitHub Actions does not tell you why it was skipped which seems to be pretty sad.  I would have hopped that it would have printed out the condition that failed to explain this.

I then pushed the commit:

```
c08ba820 "DELETE ME: Add some vertial whitespace"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Mar 25 17:36:11 2021 -0400 (26 hours ago)

M       docs/pages/bssw/bssw_content_publishing.md
```

and that triggered another invocation of the `merge-pr-to-preview.yml` workflow and produced the skipped job:

* https://github.com/bartlettroscoe/bssw.io/pull/7/checks?check_run_id=2206184385

And fetching the updated branches, the 'preview' branch is unchanged compared to 'master' as shown by:

```
$ git fetch rab-github

$ git log-short --name-status rab-github/preview --not rab-github/master
[empty]
```

That that test shows that by not adding the 'preview' label, the PR branch does **not** get merged to the 'preview' label.

[PASSED]

**B) Create a test a PR for content that will be viewed on bssw.io**

For this use case, I created the branch 'change-content-file-test-pr-preview-label-1' that pushes updates to the file:

```
CuratedContent/WorkingEffectivelyWithLegacyCode.md
```

in several commits.

I pushed the first commit:

```
b778f2d7 "Fix some whitespace"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Mar 25 18:08:18 2021 -0400 (26 hours ago)

M       CuratedContent/WorkingEffectivelyWithLegacyCode.md
```

to the branch [change-content-file-test-pr-preview-label-1](https://github.com/bartlettroscoe/bssw.io/tree/change-content-file-test-pr-preview-label-1) for which I created the initial PR:

* https://github.com/bartlettroscoe/bssw.io/pull/8

You can see that the creation of this PR fired off the `merge-pr-to-preview.yml` workflow and produced the skiped job:

* https://github.com/bartlettroscoe/bssw.io/actions/runs/691712283

I then added the label `enhancement` but I did **not** set the label `preveiw`.  That fired off the `merge-pr-to-preview.yml` workflow again and again produced a skiped job:

* https://github.com/bartlettroscoe/bssw.io/actions/runs/691712284

As of this point, the 'preview' branch has **not** been updated as shown by:

```
$ git fetch rab-github 

$ git log-short --name-status rab-github/preview --not rab-github/master
[empty]
```

Next, I added the `preview` label to that PR, without making any other changes or pushing any new commits and that triggered the `merge-pr-to-preview.yml` workflow which produced the non-skipped job:

* https://github.com/bartlettroscoe/bssw.io/actions/runs/691719762

which took 24s to run and produced the updated 'preview' branch:

```
$ git fetch rab-github
...
From github.com:bartlettroscoe/bssw.io
   342a38c6..758f3b2c  preview    -> rab-github/preview

$ git log-short --name-status rab-github/preview --not rab-github/master 

758f3b2c "Merge b778f2d74b8037f7dcc4a148208748db3856b24a into preview"
Author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Date:   Sat Mar 27 00:57:50 2021 +0000 (36 seconds ago)

b778f2d7 "Fix some whitespace"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Mar 25 18:08:18 2021 -0400 (27 hours ago)

M       CuratedContent/WorkingEffectivelyWithLegacyCode.md
```

So that worked great!

Next, I removed the `preview` label from the PR.  That did **not** trigger the `merge-pr-to-preview.yml` workflow because that workflow does not have the `unlabled` type for the `pull_request_target` event.  (We don't want to do anything if a label is removed so this is good.)

Next, I pushed the commit:

```
1ba4c4b0 "Change from - to * for some bullets"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Mar 25 18:21:24 2021 -0400 (27 hours ago)

M       CuratedContent/WorkingEffectivelyWithLegacyCode.md
```

That triggered the `merge-pr-to-preview.yml` workflow but produced as skipped job:

* https://github.com/bartlettroscoe/bssw.io/actions/runs/691730004

That is what we want because we removed the `preview` label which means that we don't want to be merging to the 'preview' branch for now.

But then I set the `preview` label for that PR without changing anything else and it triggered the `merge-pr-to-preview.yml` workflow again with the job:

* https://github.com/bartlettroscoe/bssw.io/actions/runs/691734090

which took 27s which merged the new commit an create the new commits on the 'preview' branch:

```
$ git fetch rab-github
...
From github.com:bartlettroscoe/bssw.io
   758f3b2c..f65588e6  preview    -> rab-github/preview

$ git log-short --name-status rab-github/preview --not 758f3b2c

f65588e6 "Merge 1ba4c4b02ed7004177dadddde859c970ac595063 into preview"
Author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Date:   Sat Mar 27 01:06:38 2021 +0000 (35 seconds ago)

1ba4c4b0 "Change from - to * for some bullets"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Mar 25 18:21:24 2021 -0400 (27 hours ago)

M       CuratedContent/WorkingEffectivelyWithLegacyCode.md
```

Finally, I pushed the commit:

```
1f43ffa0 "More Whitespace changes"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Mar 25 18:45:48 2021 -0400 (26 hours ago)

M       CuratedContent/WorkingEffectivelyWithLegacyCode.md
```

and the PR which already has the `preview` label set which triggered the `merge-pr-to-preview.yml` workflow again which ran the job:

* https://github.com/bartlettroscoe/bssw.io/actions/runs/691739198

which took 35s to complete and produced the new commits on the 'preview' branch:

```
$ git fetch rab-github
...
From github.com:bartlettroscoe/bssw.io
   f65588e6..c0257920  preview    -> rab-github/preview

$ git log-short --name-status rab-github/preview --not f65588e6
c0257920 "Merge 1f43ffa0525ff68b431dcf3c9d281680718683b8 into preview"
Author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
Date:   Sat Mar 27 01:10:02 2021 +0000 (70 seconds ago)

1f43ffa0 "More Whitespace changes"
Author: Roscoe A. Bartlett <rabartl@sandia.gov>
Date:   Thu Mar 25 18:45:48 2021 -0400 (26 hours ago)

M       CuratedContent/WorkingEffectivelyWithLegacyCode.md
```

That is pretty good evidence that this this `merge-pr-to-preview.yml` workflow behaves as intended.  It also shows that it works even when multiple labels are set.  NOTE: For multiple labels, you have to use the conditional:

```
if: contains(github.event.pull_request.labels.*.name, 'preview')
```

and **not** the conditional:

```
if: ${{ github.event.label.name == 'preview' }}
```

That latter fails when more than one label is set.  (I verified this during earlier development.)

</details>


## Checklist for (internal) files not displayed on bssw.io site

* [x] Set list of Reviewers (please at least one).
* [x] Add to Project `BSSw Internal`.
* [x] View the modified `*.md` files as rendered in GitHub.
* [ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.
* [ ] Watch for PR check failures.
* [ ] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [ ] Ensure at least one reviewer signs off on the changes.
* [ ] Once reviewer has approved and PR check pass, then merge the PR.


<!-- Standard links below, leave these! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[content development]: https://github.com/betterscientificsoftware/bssw.io/projects/3?
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
