### PR TITLE
Follow-on tweaks to PR template from PR #765 (#695)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ Provide a general summary of your changes in the title above.
 
 Fill in the below **Description** section with minimal text describing the changes/new contributions in this PR and replace `<...>` as appropriate.
 
-Remove the beginning `<!--` and ending `-->` comment markers for the correct **checklist** to be used for this PR and delete the other checklist.  (The checklist items for bssw.io site contributions are shown by default.  The checklist for internal files not displayed in the bssw.io site is given below that.)
+Remove the beginning `<!--` and ending `-->` comment markers for the correct **checklist** to be used for this PR and delete the other checklist.  (The checklist items for files displayed on the bssw.io site are shown by default.  The checklist items for internal files not displayed in the bssw.io site is given below with commented out checklist items by default.)
 
 Any checklist items that don't apply can be striked out by adding `~~` to the beginning and end of the checklist item as `* ~~[] <checklist-item>~~`.  Also, remove the strikeout markers `~~` for the [wikize_refs.py] checklist items if using formal citations for bssw.io contributions.
 
@@ -46,8 +46,6 @@ Addresses issue #`<issue-id>`
 * [ ] Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
 * [ ] Merge PR. Should automatically move to "Done" in [Content Development].
 * [ ] Verify new new contribution shows up on [bssw.io] as expected.
-
-NOTE: Optional checklist items can be striked out with adding `~~` to beginning and end of the checklist item as `* ~~[ ] <checklist-item>~~`.  And checklist items that are striked out by default can be re-enabled by removing their strikeout markers `~~` (e.g. for the `wikize_refs.py` items).
 
 <!-- NOTE: Remove above checklist if using the below checklist for internal files. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,7 +47,7 @@ Addresses issue #`<issue-id>`
 * [ ] Merge PR. Should automatically move to "Done" in [Content Development].
 * [ ] Verify new new contribution shows up on [bssw.io] as expected.
 
-NOTE: Optional checklist items can be striked out with adding `~~` to beginning and end of the checklist item as `* ~~[ ] <checklist-item>~~`.
+NOTE: Optional checklist items can be striked out with adding `~~` to beginning and end of the checklist item as `* ~~[ ] <checklist-item>~~`.  And checklist items that are striked out by default can be re-enabled by removing their strikeout markers `~~` (e.g. for the `wikize_refs.py` items).
 
 <!-- NOTE: Remove above checklist if using the below checklist for internal files. -->
 


### PR DESCRIPTION
# Description

EB Member: @markcmiller86 

Addresses issue #695

Follow-on tweaks to address feedback for the PR template first merged in PR #765.


## PR checklist for (internal) files not displayed on bssw.io site

* [x] Set list of Reviewers (at least one).
* [x] Add to Project [BSSw Internal].
* [ ] View the modified `*.md` files as rendered in GitHub.
* [ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.
* [ ] Watch for PR check failures.
* [ ] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [ ] Ensure at least one reviewer signs off on the changes.
* [ ] Once reviewer has approved and PR check pass, then merge the PR.


<!-- Standard links below, leave these this section! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
