### PR TITLE
Fixup 'preview' and wikize_refs.py documentation (#702, #704)

### DIFF
--- a/Articles/Blog/ReferencesInMarkdownHybridApproach-wikized.md
+++ b/Articles/Blog/ReferencesInMarkdownHybridApproach-wikized.md
@@ -12,7 +12,7 @@ not convenient.
 
 Here, we describe conventions in the use of [GitHub Flavored Markdown (GFM)][GFM]
 together with a Python post-processing script
-[`wikize_refs.py`](../../utils/wikize_refs.py)
+[`wikize_refs.py`](../../utils/README.md#wikize_refspy)
 to make it easier to manage such references in a
 [Wikipedia-like way](https://en.wikipedia.org/wiki/Note_(typography)#References).
 

--- a/Articles/Blog/ReferencesInMarkdownHybridApproach.md
+++ b/Articles/Blog/ReferencesInMarkdownHybridApproach.md
@@ -12,7 +12,7 @@ not convenient.
 
 Here, we describe conventions in the use of [GitHub Flavored Markdown (GFM)][GFM]
 together with a Python post-processing script
-[`wikize_refs.py`](../../utils/wikize_refs.py)
+[`wikize_refs.py`](../../utils/README.md#wikize_refspy)
 to make it easier to manage such references in a
 [Wikipedia-like way](https://en.wikipedia.org/wiki/Note_(typography)#References).
 

--- a/docs/pages/bssw/bssw_content_publishing.md
+++ b/docs/pages/bssw/bssw_content_publishing.md
@@ -46,7 +46,8 @@ The following steps assume that the BSSw editorial team has already determined t
 
 ### Pre-publishing Checks
 * Finalize the topic(s) and other parameters in metadata.
-* Ensure [`wikize_refs.py -i <base>.md`](https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy) is run and commit before previewing (if `wikize_refs.py` is being used).
+* Ensure [`wikize_refs.py -i <base>.md`](https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy) is run and commit (if `wikize_refs.py` is being used).
+* Add the `preview` label to the PR (so PR branch will merge to 'preview' branch which is used to generate preview site).
 * Update and sanity check on preview site to confirm overall display ("publish: preview" in metadata).
 * Change "publish: yes" in metadata before merging the PR to 'master'.
 

--- a/docs/pages/bssw/bssw_content_publishing.md
+++ b/docs/pages/bssw/bssw_content_publishing.md
@@ -46,9 +46,8 @@ The following steps assume that the BSSw editorial team has already determined t
 
 ### Pre-publishing Checks
 * Finalize the topic(s) and other parameters in metadata.
-* Ensure [`wikize_refs.py -i <base>.md`](https://github.com/betterscientificsoftware/bssw.io/blob/master/Articles/Blog/ReferencesInMarkdownHybridApproach.md) is run and commit before previewing (if `wikize_refs.py` is being used).
+* Ensure [`wikize_refs.py -i <base>.md`](https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy) is run and commit before previewing (if `wikize_refs.py` is being used).
 * Update and sanity check on preview site to confirm overall display ("publish: preview" in metadata).
 * Change "publish: yes" in metadata before merging the PR to 'master'.
-* Ensure [`wikize_refs.py -i <base>.md`](https://github.com/betterscientificsoftware/bssw.io/blob/master/Articles/Blog/ReferencesInMarkdownHybridApproach.md) is run and commit before merging the PR to 'master' (if `wikize_refs.py` is being used).
 
 {% include links.html %}

--- a/docs/pages/bssw/bssw_pr_preview_branch.md
+++ b/docs/pages/bssw/bssw_pr_preview_branch.md
@@ -50,7 +50,7 @@ figure.
 
 This is a simplification of the [throw-away integration test
 branch](https://docs.google.com/document/d/1uVQYI2cmNx09fDkHDA136yqDTqayhxqfvjFiuUue7wo#heading=h.2r0g9kvx5b2a)
-where the `preview` branch takes the place of the 'next' branch.
+where the `preview` branch takes the place of the `next` branch.
 
 In this setup, the production https://bssw.io site is generated from the
 `master` branch while the https://preview.bssw.io site is generated from the
@@ -110,6 +110,8 @@ The commands to merge an updated `content-X` branch to `preview` are:
 [ (preview)]$ git push       # to origin/preview
 ```
 
+These commands are performed automatically by the Github Actions [`merge-pr-to-preview.yml`](https://github.com/betterscientificsoftware/bssw.io/blob/master/.github/workflows/merge-pr-to-preview.yml) workflow when the `preview` label is set on the PR for the branch `content-x` and whenever new commits are pushed to the PR branch when that label is set.  (If the `preview` label is not set, then the PR branch is not automatically merged to the `preview` branch.)
+
 The commands to update the `preview` branch after a `content-X` branch and PR
 has been "graduated" (i.e. merged to `master`), or any updates to the `master`
 branch are made, are:
@@ -121,9 +123,7 @@ branch are made, are:
 [ (preview)]$ git push       # to origin/preview
 ```
 
-The merges of `context-X` branches to `preview` and merges of `master` to
-`preview` are done automatically using [registered GitHub
-Actions](https://github.com/betterscientificsoftware/bssw.io/tree/master/.github/workflows).
+These commands are performed automatically by the GitHub Actions [merge-master-to-preview.yml](https://github.com/betterscientificsoftware/bssw.io/blob/master/.github/workflows/merge-master-to-preview.yml) workflow whenever new commits are pushed to the `master` branch (either by merging a PR to `master` or direct pushes to `master`).
 
 <a name="unpublish"/>
 
@@ -143,7 +143,7 @@ https://preview.bssw.io site, one can do one of the following:
 NOTE: In the future, removing content from PRs that were closed without
 merging to the `master` branch could be handled automatically (e.g. by
 rebuilding the `preview` branch from scratch each time new commits are pushed
-to a PR branch).
+to a PR branch for open PRs or to `master`).
 
 To unpublish a contribution already published to `master` and displayed on the
 main https://bssw.io site, one can do one of the following:


### PR DESCRIPTION
# Description

Addresses issues #702, #744

Some small improvements I saw that could be made after reviewing this documentation.

NOTE: I can't get the figure to show up in the `bssw_pr_preview_branch.html` page on the Jekyll rendered site.

See commit log messages for more details.

## PR checklist for (internal) files not displayed on bssw.io site

* [x] Set list of Reviewers (at least one).
* [x] Add to Project [BSSw Internal].
* [x] View the modified `*.md` files as rendered in GitHub.
* [x] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.
* [x] Watch for PR check failures.
* [x] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [x] Ensure at least one reviewer signs off on the changes.
* [ ] Once reviewer has approved and PR check pass, then merge the PR.


<!-- Standard links below, leave these this section! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
