### PR TITLE
Add role prefix to checklist items and rearrange to group by author (#695)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,32 +24,32 @@ Addresses issue #`<issue-id>`
 
 ## PR checklist for files displayed on bssw.io site
 
-* [ ] *[Author]* `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
-* [ ] *[Author]* Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
-* [ ] *[EB Mem]* Assign this PR to the EB member `<eb-member-id>`.
-* [ ] *[EB Mem]* Assign this PR to the author of the PR `<pr-author-id>`.
-* [ ] *[EB Mem]* Add label `content: <content-type>` for the type of contribution.
-* [ ] *[EB Mem]* Add to Project `Content Development` (see [Content Development]).
-* [ ] *[Author]* Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
-* [ ] *[Author]* Add one or more Reviewers.
-* [ ] *[EB Mem]* Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
-* ~~[ ] *[Author]* Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py])~~.
-* [ ] *[EB Mem]* Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
-* [ ] *[EB Mem]* Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
-* [ ] *[Author]* Make any final changes to the PR based on feedback.
-* ~~[ ] *[Author]* Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py]).~~
-* [ ] *[EB Mem]* Rebuild [preview] site and re-confirm content looks correct.
-* [ ] *[EB Mem]* Ensure at least one reviewer signs off on the final changes.
-* [ ] *[EB Mem]* Change meta-data to `Publish: yes` and commit if fully ready to publish.
-* [ ] *[EB Mem]* Move the PR to "Ready to Publish" in [Content Development].
-* [ ] *[EB Mem]* Assign to one of the site maintainers to carry out final publication steps.
-* [ ] *[EB Mem]* Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
-* [ ] *[EB Mem]* Merge PR. Should automatically move to "Done" in [Content Development].
-* [ ] *[EB Mem]* Verify new new contribution shows up on [bssw.io] as expected.
+* [ ] ***[Author]*** `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
+* [ ] ***[Author]*** Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
+* [ ] ***[EB Mem]*** Assign this PR to the EB member `<eb-member-id>`.
+* [ ] ***[EB Mem]*** Assign this PR to the author of the PR `<pr-author-id>`.
+* [ ] ***[EB Mem]*** Add label `content: <content-type>` for the type of contribution.
+* [ ] ***[EB Mem]*** Add to Project `Content Development` (see [Content Development]).
+* [ ] ***[Author]*** Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
+* [ ] ***[Author]*** Add one or more Reviewers.
+* [ ] ***[EB Mem]*** Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
+* ~~[ ] ***[Author]*** Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py])~~.
+* [ ] ***[EB Mem]*** Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
+* [ ] ***[EB Mem]*** Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
+* [ ] ***[Author]*** Make any final changes to the PR based on feedback.
+* ~~[ ] ***[Author]*** Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py]).~~
+* [ ] ***[EB Mem]*** Rebuild [preview] site and re-confirm content looks correct.
+* [ ] ***[EB Mem]*** Ensure at least one reviewer signs off on the final changes.
+* [ ] ***[EB Mem]*** Change meta-data to `Publish: yes` and commit if fully ready to publish.
+* [ ] ***[EB Mem]*** Move the PR to "Ready to Publish" in [Content Development].
+* [ ] ***[EB Mem]*** Assign to one of the site maintainers to carry out final publication steps.
+* [ ] ***[EB Mem]*** Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
+* [ ] ***[EB Mem]*** Merge PR. Should automatically move to "Done" in [Content Development].
+* [ ] ***[EB Mem]*** Verify new new contribution shows up on [bssw.io] as expected.
 
 NOTE:
-* Checklist items prefixed with *[Author]* are expected to be performed by the author of the PR or can be performed by the author.
-* Checklist items prefixed with *[EB Mem]* must be performed by a [BSSw.io Editorial Board (EB) Member](https://betterscientificsoftware.github.io/bssw.io/bssw_members.html).
+* Checklist items prefixed with ***[Author]*** are expected to be performed by the author of the PR or can be performed by the author.
+* Checklist items prefixed with ***[EB Mem]*** must be performed by a [BSSw.io Editorial Board (EB) Member](https://betterscientificsoftware.github.io/bssw.io/bssw_members.html).
 
 <!-- NOTE: Remove above checklist if using the below checklist for internal files. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,7 +44,7 @@ Addresses issue #`<issue-id>`
 * [ ] ***[EB Mem]*** Move the PR to "Ready to Publish" in [Content Development].
 * [ ] ***[EB Mem]*** Assign to one of the site maintainers to carry out final publication steps.
 * [ ] ***[EB Mem]*** Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
-* [ ] ***[EB Mem]*** Merge PR. Should automatically move to "Done" in [Content Development].
+* [ ] ***[EB Mem]*** Merge PR. (Should automatically move to "Done" in [Content Development].)
 * [ ] ***[EB Mem]*** Verify new new contribution shows up on [bssw.io] as expected.
 
 NOTE:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,14 +26,14 @@ Addresses issue #`<issue-id>`
 
 * [ ] ***[Author]*** `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
 * [ ] ***[Author]*** Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
+* [ ] ***[Author]*** Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
+* ~~[ ] ***[Author]*** Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py])~~.
 * [ ] ***[EB Mem]*** Assign this PR to the EB member `<eb-member-id>`.
 * [ ] ***[EB Mem]*** Assign this PR to the author of the PR `<pr-author-id>`.
+* [ ] ***[EB Mem]*** Add one or more Reviewers.
 * [ ] ***[EB Mem]*** Add label `content: <content-type>` for the type of contribution.
 * [ ] ***[EB Mem]*** Add to Project `Content Development` (see [Content Development]).
-* [ ] ***[Author]*** Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
-* [ ] ***[Author]*** Add one or more Reviewers.
 * [ ] ***[EB Mem]*** Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
-* ~~[ ] ***[Author]*** Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py])~~.
 * [ ] ***[EB Mem]*** Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
 * [ ] ***[EB Mem]*** Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
 * [ ] ***[Author]*** Make any final changes to the PR based on feedback.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -26,8 +26,8 @@ Addresses issue #`<issue-id>`
 
 * [ ] ***[Author]*** `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
 * [ ] ***[Author]*** Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
-* [ ] ***[Author]*** Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
 * ~~[ ] ***[Author]*** Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py])~~.
+* [ ] ***[Author]*** Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
 * [ ] ***[EB Mem]*** Assign this PR to the EB member `<eb-member-id>`.
 * [ ] ***[EB Mem]*** Assign this PR to the author of the PR `<pr-author-id>`.
 * [ ] ***[EB Mem]*** Add one or more Reviewers.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,28 +24,32 @@ Addresses issue #`<issue-id>`
 
 ## PR checklist for files displayed on bssw.io site
 
-* [ ] `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
-* [ ] Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
-* [ ] Assign this PR to the EB member `<eb-member-id>`.
-* [ ] Assign this PR to the author of the PR `<pr-author-id>`.
-* [ ] Add label `content: <content-type>` for the type of contribution.
-* [ ] Add to Project `Content Development` (see [Content Development]).
-* [ ] Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
-* [ ] Add one or more Reviewers.
-* [ ] Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
-* ~~[ ] Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py])~~.
-* [ ] Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
-* [ ] Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
-* [ ] Make any final changes to the PR based on feedback.
-* ~~[ ] Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py]).~~
-* [ ] Rebuild [preview] site and re-confirm content looks correct.
-* [ ] Ensure at least one reviewer signs off on the final changes.
-* [ ] Change meta-data to `Publish: yes` and commit if fully ready to publish.
-* [ ] Move the PR to "Ready to Publish" in [Content Development].
-* [ ] Assign to one of the site maintainers to carry out final publication steps.
-* [ ] Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
-* [ ] Merge PR. Should automatically move to "Done" in [Content Development].
-* [ ] Verify new new contribution shows up on [bssw.io] as expected.
+* [ ] *[Author]* `@mention` the BSSw.io editorial board member `@<eb-member-id>` in **Description** above assigned to shepherd your PR.
+* [ ] *[Author]* Add the `<issue-id>` in the **Description** above for the associated GitHub Issue.
+* [ ] *[EB Mem]* Assign this PR to the EB member `<eb-member-id>`.
+* [ ] *[EB Mem]* Assign this PR to the author of the PR `<pr-author-id>`.
+* [ ] *[EB Mem]* Add label `content: <content-type>` for the type of contribution.
+* [ ] *[EB Mem]* Add to Project `Content Development` (see [Content Development]).
+* [ ] *[Author]* Inspect the content in the `*.md` file(s) as rendered in GitHub for this PR.
+* [ ] *[Author]* Add one or more Reviewers.
+* [ ] *[EB Mem]* Add [meta-data] to the `*.md` file(s) (set `Publish: preview`).
+* ~~[ ] *[Author]* Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py])~~.
+* [ ] *[EB Mem]* Add label `preview` (so PR branch will be merged to 'preview' branch and watch for possible merge failures).
+* [ ] *[EB Mem]* Rebuild [preview] site and confirm new content is there, renders correctly and is returned in searches.
+* [ ] *[Author]* Make any final changes to the PR based on feedback.
+* ~~[ ] *[Author]* Ensure `wikize_refs.py -i <base>.md` is run and commit (if using [wikize_refs.py]).~~
+* [ ] *[EB Mem]* Rebuild [preview] site and re-confirm content looks correct.
+* [ ] *[EB Mem]* Ensure at least one reviewer signs off on the final changes.
+* [ ] *[EB Mem]* Change meta-data to `Publish: yes` and commit if fully ready to publish.
+* [ ] *[EB Mem]* Move the PR to "Ready to Publish" in [Content Development].
+* [ ] *[EB Mem]* Assign to one of the site maintainers to carry out final publication steps.
+* [ ] *[EB Mem]* Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
+* [ ] *[EB Mem]* Merge PR. Should automatically move to "Done" in [Content Development].
+* [ ] *[EB Mem]* Verify new new contribution shows up on [bssw.io] as expected.
+
+NOTE:
+* Checklist items prefixed with *[Author]* are expected to be performed by the author of the PR or can be performed by the author.
+* Checklist items prefixed with *[EB Mem]* must be performed by a [BSSw.io Editorial Board (EB) Member](https://betterscientificsoftware.github.io/bssw.io/bssw_members.html).
 
 <!-- NOTE: Remove above checklist if using the below checklist for internal files. -->
 


### PR DESCRIPTION
# Description

Addresses issues #330, #695

As discussed in the BSSw.io meeting on 4/8/2021, this PR prefixes the checklist items by role to make it clear what the Author needs to do and what the EB Member needs to do.  I also rearranged the checklist items some so that the items the author must/should do are grouped together as much as possible.  See the individual commits for more detail.  To view the rendered updated PR template, see [PULL_REQUEST_TEMPLATE.md](https://github.com/bartlettroscoe/bssw.io/blob/695-pr-checklist-role-prefix/.github/PULL_REQUEST_TEMPLATE.md).


## PR checklist for (internal) files not displayed on bssw.io site

* [x] Set list of Reviewers (at least one).
* [x] Add to Project [BSSw Internal].
* [x] View the modified `*.md` files as rendered in GitHub.
* ~~[ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.~~
* [x] Watch for PR check failures.
* [ ] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [ ] Ensure at least one reviewer signs off on the changes.
* [ ] Once reviewer has approved and PR check pass, then merge the PR.


<!-- Standard links below, leave these this section! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
