### PR TITLE
Example of pure-markdown solution

### DIFF
--- a/Articles/Blog/2021-05-reftest2.md
+++ b/Articles/Blog/2021-05-reftest2.md
@@ -186,18 +186,9 @@ END ORIGINAL LINK DEFS -->
 
 ### References
 
-<div class="references-wrapper">
-<div class="references">
-<a name="ref1" href="https://www.britannica.com/technology/Moores-law">Moore’s Law</a>
-<a name="ref2" href="https://www.rambus.com/blogs/understanding-dennard-scaling-2/">Dennard Scaling</a>
-<a name="ref3" href="https://www.nature.com/news/the-chips-are-down-for-moore-s-law-1.19338">The Chips are Down for Moore’s Law</a>
-<a name="ref4" href="https://www.omnisci.com/technical-glossary/hardware-acceleration">Hardware Acceleration Definition</a>
-</div>
-
-<div class="references">
-<a name="ref5" href="https://www.top500.org/">Top 500: The List</a>
-<a name="ref6" href="https://www.olcf.ornl.gov/olcf-resources/compute-systems/summit/">Summit: Oak Ridge National Laboratory’s 200 Petaflop Supercomputer</a>
-<a name="ref7" href="https://docs.nersc.gov/systems/cori/">Cori</a>
-<a name="ref8" href="https://docs.nersc.gov/tools/performance/roofline/">Roofline Performance Model</a>
- </div>
- </div>
+&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;  | &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
+:--- | :--- 
+<sup>1</sup><a name="ref1" href="https://www.britannica.com/technology/Moores-law">Moore’s Law</a> | <sup>5</sup><a name="ref5" href="https://www.top500.org/">Top 500: The List</a>
+<sup>2</sup><a name="ref2" href="https://www.rambus.com/blogs/understanding-dennard-scaling-2/">Dennard Scaling</a> | <sup>6</sup><a name="ref6" href="https://www.olcf.ornl.gov/olcf-resources/compute-systems/summit/">Summit: Oak Ridge National Laboratory’s 200 Petaflop Supercomputer</a> 
+<sup>3</sup><a name="ref3" href="https://www.nature.com/news/the-chips-are-down-for-moore-s-law-1.19338">The Chips are Down for Moore’s Law</a> | <sup>7</sup><a name="ref7" href="https://docs.nersc.gov/systems/cori/">Cori</a>
+<sup>4</sup><a name="ref4" href="https://www.omnisci.com/technical-glossary/hardware-acceleration">Hardware Acceleration Definition</a> | <sup>8</sup><a name="ref8" href="https://docs.nersc.gov/tools/performance/roofline/">Roofline Performance Model</a>


### PR DESCRIPTION
Just adding this as a pure markdown solution. It does a few things "better" than we currently do in `wikize_refs.py`...

* Does ref. list as two column
* Equalizes column widts (with ugly bunch of `&nbsp;` in header
* Does away with using a table column for footnote lables (e.g. numbers) and instead shows those as super-scripts just *ahead* of each ref.

I like this. I think its easy to make `wikize_refs.py` do this. We can of course have `wikize_refs.py` also and the HTML `<div>` items to give back-end CSS styling hints.