### PR TITLE
Update PR checklist changing last items to 'BSSw Maint' (#330)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,7 +42,7 @@ Addresses issue #`<issue-id>`
 * [ ] ***[EB Mem]*** Ensure at least one reviewer signs off on the final changes.
 * [ ] ***[EB Mem]*** Change meta-data to `Publish: yes` and commit if fully ready to publish.
 * [ ] ***[EB Mem]*** Move the PR to "Ready to Publish" in [Content Development].
-* [ ] ***[EB Mem]*** Assign to a bssw.io site maintainer (**BSSw Maint**) to carry out final publication steps.
+* [ ] ***[EB Mem]*** Leave comment @mentioning a bssw.io site maintainer (**BSSw Maint**) asking to carry out final publication steps.
 * [ ] ***[BSSw Maint]*** Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
 * [ ] ***[BSSw Maint]*** Merge PR. (Should automatically move to "Done" in [Content Development].)
 * [ ] ***[BSSw Maint]*** Verify new new contribution shows up on [bssw.io] as expected.
@@ -50,7 +50,7 @@ Addresses issue #`<issue-id>`
 NOTE:
 * Checklist items prefixed with ***[Author]*** are expected to be performed by the author of the PR or can be performed by the author.
 * Checklist items prefixed with ***[EB Mem]*** must be performed by a [BSSw.io Editorial Board (EB) Member](https://betterscientificsoftware.github.io/bssw.io/bssw_members.html).
-* Checklist items prefixed with ***[BSSw Maint]*** must be performed by a bssw.io site maintainer (currently @rinkug)
+* Checklist items prefixed with ***[BSSw Maint]*** must be performed by a bssw.io site maintainer (currently 'rinkug')
 
 <!-- NOTE: Remove above checklist if using the below checklist for internal files. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -42,14 +42,15 @@ Addresses issue #`<issue-id>`
 * [ ] ***[EB Mem]*** Ensure at least one reviewer signs off on the final changes.
 * [ ] ***[EB Mem]*** Change meta-data to `Publish: yes` and commit if fully ready to publish.
 * [ ] ***[EB Mem]*** Move the PR to "Ready to Publish" in [Content Development].
-* [ ] ***[EB Mem]*** Assign to one of the site maintainers to carry out final publication steps.
-* [ ] ***[EB Mem]*** Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
-* [ ] ***[EB Mem]*** Merge PR. (Should automatically move to "Done" in [Content Development].)
-* [ ] ***[EB Mem]*** Verify new new contribution shows up on [bssw.io] as expected.
+* [ ] ***[EB Mem]*** Assign to a bssw.io site maintainer (**BSSw Maint**) to carry out final publication steps.
+* [ ] ***[BSSw Maint]*** Verify that all needed files are present in the PR (article, images, updates to Site/Homepage.md carousel and/or Site/Announcements/Announcements.md as appropriate).
+* [ ] ***[BSSw Maint]*** Merge PR. (Should automatically move to "Done" in [Content Development].)
+* [ ] ***[BSSw Maint]*** Verify new new contribution shows up on [bssw.io] as expected.
 
 NOTE:
 * Checklist items prefixed with ***[Author]*** are expected to be performed by the author of the PR or can be performed by the author.
 * Checklist items prefixed with ***[EB Mem]*** must be performed by a [BSSw.io Editorial Board (EB) Member](https://betterscientificsoftware.github.io/bssw.io/bssw_members.html).
+* Checklist items prefixed with ***[BSSw Maint]*** must be performed by a bssw.io site maintainer (currently @rinkug)
 
 <!-- NOTE: Remove above checklist if using the below checklist for internal files. -->
 


### PR DESCRIPTION
# Description

As discussed at the BSSw.io meeting on 4/5/2021, we need to change the last few checklist items to be done by a new role **BSSw Maint**.  @rinkug said for now to specifically assign this role to her to finish up the checklist and merge the PR.

## PR checklist for (internal) files not displayed on bssw.io site

* [x] Set list of Reviewers (at least one).
* [x] Add to Project [BSSw Internal].
* [x] View the modified `*.md` files as rendered in GitHub.
* ~~[ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.~~
* [x] Watch for PR check failures.
* [x] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [x] Ensure at least one reviewer signs off on the changes.
* [x] Once reviewer has approved and PR check pass, then merge the PR.


<!-- Standard links below, leave these this section! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
