### PR TITLE
Minor Article Fixes - May Digest

### DIFF
--- a/Articles/Blog/2021-05-experiences-bssw-community-bof.md
+++ b/Articles/Blog/2021-05-experiences-bssw-community-bof.md
@@ -7,7 +7,7 @@
 #### Contributed by: [Rinku Gupta](https://github.com/rinkug), [Avanthi Madduri](https://github.com/mantrala-ops) and [Deborah Stevens](https://github.com/haikudeb)
 #### Publication Date: May 26, 2021
 
-In March 2020, the Exascale Computing Project (ECP) organized a series of Community Birds-of-a-Feather (BOF) Days to provide an opportunity for the HPC and ECP communities to converge and discuss the latest development efforts. The BSSw.io editorial team led a community BOF on *"Cultivating Software Sustainability, Productivity and Quality through BSSw.io"*. This session was a great success, with over 50 attendees representing academia, national laboratories and supercomputing centers. 
+In March 2021, the Exascale Computing Project (ECP) organized a series of Community Birds-of-a-Feather (BOF) Days to provide an opportunity for the HPC and ECP communities to converge and discuss the latest development efforts. The BSSw.io editorial team led a community BOF on *"Cultivating Software Sustainability, Productivity and Quality through BSSw.io"*. This session was a great success, with over 50 attendees representing academia, national laboratories and supercomputing centers. 
 
 Avanthi Madduri and Deborah Stevens, from the [Argonne Leadership Computing Facility](https://www.alcf.anl.gov/), interview Rinku Gupta. Rinku was the lead organizer of the BSSw.io community BOF and also serves as Editor-in-Chief of the BSSw.io site.
 

--- a/CuratedContent/Debuggingbooks.md
+++ b/CuratedContent/Debuggingbooks.md
@@ -15,7 +15,7 @@ Article title | [The Ghosts in the Debugging](https://third-bit.com/2021/03/27/g
 Authors | Greg Wilson	
 Focus | Software testing, debugging
 
-The article *[The Ghosts in the Debugging](https://third-bit.com/2021/03/27/ghosts-in-debugging/)*, by [Greg Wilson](https://third-bit.com/), lists a collection of books for understanding how debuggers and debugging works that are useful for novice and experienced software engineers. Greg Wilson also lists several other books that are works-in-progress but may still be useful for readers. 
+The article *[The Ghosts in the Debugging](https://third-bit.com/2021/03/27/ghosts-in-debugging/)*, by [Greg Wilson](https://third-bit.com/), lists a collection of books for understanding how debuggers and debugging works that are useful for novice and experienced software engineers. Wilson also lists several other books that are works-in-progress but may still be useful for readers. 
 
 
 Resource information | Details 

--- a/CuratedContent/IntroHPCResources.md
+++ b/CuratedContent/IntroHPCResources.md
@@ -1,5 +1,5 @@
 
-# An Introductory Resource for High-performance Computing
+# An Introductory Resource for High-Performance Computing
 
 <!--- deck text start --->
 
@@ -15,16 +15,16 @@ Resource information | Details
 :--- | :--- 
 Paper title | Survey of Methodologies, Approaches, and Challenges in Parallel Programming Using High-Performance Computing Systems
 Authors | Pedro Valero-Lara, Paweł Czarnul, Jerzy Proficz and Krzysztof Drypczewski
-Publication | Year 2020, Scientific Programming Journal, DOI: [10.1155/2020/4176794](https://doi.org/10.1155/2020/4176794)
+Publication | 2020, Scientific Programming Journal, DOI: [10.1155/2020/4176794](https://doi.org/10.1155/2020/4176794)
 Length | ~8,500 words, 45 min. read
 
 <!--- deck body start --->
 
-The *Survey of Methodologies, Approaches, and Challenges in Parallel Programming Using High-Performance Computing Systems* paper was published in 2020 in Scientific Programming Open Access Journal. This article provides a good start for identifying and understanding some of current trends in high-performance computing and some of the challenges to be addressed in the near future. 
+The *Survey of Methodologies, Approaches, and Challenges in Parallel Programming Using High-Performance Computing Systems* paper was published in 2020 in the Scientific Programming Open Access Journal. This article provides a good start for identifying and understanding some current trends in high-performance computing and some of the challenges to be addressed in the near future. 
 
 The paper provides a review of some of the contemporary methodologies and APIs for parallel programming. It also gives examples of representational technologies and classifies them by target system type, memory types, one-sided/two-sided communication patterns, and programming abstraction level. The representative technologies are further analyzed based on other criteria such as programming model, languages, supported platforms, license, optimization goals, ease of programming, debugging, deployment, portability, level of parallelism etc.
 
-BSSw.io readers, who have some scientific computing background, but are relatively new to HPC and are short on time, can glean a high-level overview of HPC methodologies and practices from this paper. The reference list also provides some resources for delving deeper into each of the specific topics mentioned in the paper.
+BSSw.io readers, who have some scientific computing background but are relatively new to HPC and are short on time, can glean a high-level overview of HPC methodologies and practices from this paper. The reference list also provides some resources for delving deeper into each of the specific topics mentioned in the paper.
 
 <!--- deck body end --->
 

--- a/Events/hpcbp-053-psip4hdf.md
+++ b/Events/hpcbp-053-psip4hdf.md
@@ -13,7 +13,7 @@ high-performance computers (HPC) and occur approximately monthly.
 
 Resource Information | Details
 :--- | :---			   
-Webinar Title | Using the PSIP Toolkit to Achieve your Goals – A Case study at The HDF Group
+Webinar Title | Using the PSIP Toolkit to Achieve Your Goals – A Case Study at The HDF Group
 Date and Time | 2021-06-09 01:00 pm EDT
 Presenters | Elena Pourmal (The HDF Group), Reed Milewicz (Sandia National Laboratories),  and Elsa Gonsiorowski (Lawrence Livermore National Laboratory)
 Registration, Information, and Archives | 	<https://ideas-productivity.org/events/hpc-best-practices-webinars/#webinar053>	   
@@ -21,7 +21,7 @@ Registration, Information, and Archives | 	<https://ideas-productivity.org/event
 **Webinars are free and open to the public, but advance registration is required through the Event website. Archives (recording, slides, Q&A) will be posted at the same link soon after the event.**
 
 ### Abstract
-<p>Productivity and Sustainability Improvement Planning (PSIP) is a lightweight, iterative workflow that allows software development teams to identify development bottlenecks and track progress toward goals to overcome them. In this talk, we present an overview of the PSIP methodology and toolkit, and describe how the HDF5 Group used PSIP to make improvements in three key areas of their software development process.</p>
+<p>Productivity and Sustainability Improvement Planning (PSIP) is a lightweight, iterative workflow that allows software teams to identify development bottlenecks and track progress toward goals to overcome them. In this talk, we present an overview of the PSIP methodology and toolkit, and describe how the HDF5 Group used PSIP to make improvements in three key areas of their software development process.</p>
 
 
 


### PR DESCRIPTION
PSIP Toolkit Webinar:

These are bunch of edits to articles that will be featured in the may 2021 bssw.io digest
* Fixed capitalization of title in deck table, to conform with style guide.
* Removed a redundant use of the word "development".
* * more minor edits