### PR TITLE
Add ability to submit test results to CDash

### DIFF
--- a/utils/.gitignore
+++ b/utils/.gitignore
@@ -1,1 +1,2 @@
 /build_tests/
+/Testing/

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 project(BsswUtils NONE)
+include(CTest)
 enable_testing()
 add_subdirectory(tests)

--- a/utils/CTestConfig.cmake
+++ b/utils/CTestConfig.cmake
@@ -1,0 +1,6 @@
+set(CTEST_PROJECT_NAME "BsswUtils")
+set(CTEST_NIGHTLY_START_TIME "01:00:00 UTC")
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "my.cdash.org")
+set(CTEST_DROP_LOCATION "/submit.php?project=${CTEST_PROJECT_NAME}")
+set(CTEST_DROP_SITE_CDASH YES)

--- a/utils/README.md
+++ b/utils/README.md
@@ -38,3 +38,9 @@ This can also be done in one shot by running:
 ```
 ./run_tests.sh
 ```
+
+One can also run the tests locally and submit to CDash with:
+
+```
+./run_tests_submit_to_cdash.sh
+```

--- a/utils/run_tests_submit_to_cdash.sh
+++ b/utils/run_tests_submit_to_cdash.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# Simple driver to run tests in one command
+
+if [[ ! -d build_tests ]] ; then
+    mkdir build_tests
+fi
+
+cd build_tests/
+
+if [[ -e CMakeCache.txt ]] || [[ -d CMakeFiles/ ]] ; then
+  rm -r CMake*
+fi
+
+cmake ..
+
+ctest -M Experimental -T Start -T Test -T Submit
+
+echo
+echo "See results at https://my.cdash.org/index.php?project=BsswUtils"


### PR DESCRIPTION
# Description

Adds ability to run and submit test results to CDash at:

* https://my.cdash.org/index.php?project=BsswUtils

See updated [utils/README.md](https://github.com/betterscientificsoftware/bssw.io/blob/utils-tests-submit-to-cdash/utils/README.md) file.

NOTE: The tests are currently failing for this version of master as shown at:

* https://my.cdash.org/viewTest.php?buildid=2030111

## PR checklist for (internal) files not displayed on bssw.io site

* [x] Set list of Reviewers (at least one).
* [x] Add to Project [BSSw Internal].
* ~~[ ] View the modified `*.md` files as rendered in GitHub.~~
* ~~[ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.~~
* [x] Watch for PR check failures.
* [x] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [x] Ensure at least one reviewer signs off on the changes.
* [x] Once reviewer has approved and PR check pass, then merge the PR.

<!-- Standard links below, leave these this section! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
