### PR TITLE
Make the link to bssw_wikize_refs work correctly in jekll-generated site (Against #927)

### DIFF
--- a/docs/pages/bssw/bssw_styling_common.md
+++ b/docs/pages/bssw/bssw_styling_common.md
@@ -81,7 +81,7 @@ Certain content types on [bssw.io](https://bssw.io) do not require formal refere
 
 * Content that in the judgment of EB members and/or authors requires references to more fully support perhaps sensitive and/or controversial positions (e.g. the Covid19 article).
 
-The decision to *allow* or *require* references is one that should be agreed upon by the author and EB members prior to developing the content. When references are to be used, we require authors to use the less intrusive [reference links](https://www.markdownguide.org/basic-syntax#reference-style-links) ([full spec](https://github.github.com/gfm/#reference-link)) and to follow the guidelines described [here](bssw_wikize_refs.md) where the [`wikize_refs.py`](https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy) tool can be helpful.
+The decision to *allow* or *require* references is one that should be agreed upon by the author and EB members prior to developing the content. When references are to be used, we require authors to use the less intrusive [reference links](https://www.markdownguide.org/basic-syntax#reference-style-links) ([full spec](https://github.github.com/gfm/#reference-link)) and to follow the guidelines described [here](bssw_wikize_refs.html) where the [`wikize_refs.py`](https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy) tool can be helpful.
 
 ## Nonstandard handling of Markdown
 

--- a/docs/pages/bssw/bssw_wikize_refs.md
+++ b/docs/pages/bssw/bssw_wikize_refs.md
@@ -1,4 +1,9 @@
-# Wikipedia-Like Citations and References In GitHub Markdown
+---
+title: Wikipedia-Like Citations and References In GitHub Markdown
+sidebar: bssw_sidebar
+permalink: bssw_wikize_refs.html
+toc: false
+---
 
 #### Contributed by [Mark C. Miller](https://github.com/markcmiller86)
 


### PR DESCRIPTION
Staggered PR against #927.

Makes the link to `bssw_wikize_refs` work correctly in jekll-generated site.  Otherwise, the link just did not work and does not make sense.

I tested this out with locally generated jekyll site and verified this works.
