### PR TITLE
Update documentation for move to images/ subdir (#703)

### DIFF
--- a/docs/pages/bssw/bssw_styling_common.md
+++ b/docs/pages/bssw/bssw_styling_common.md
@@ -59,13 +59,18 @@ These indicate which BSSw.io topic areas the article belongs to. The most up-to-
 The main body is the portion of the article below the deck. BSSw.io uses [Github-Flavored Markdown](https://guides.github.com/features/mastering-markdown/) for writing content. The elements of the main body differ based on content type. The main body should explain the content from the perspective of the CSE community. There may be image file (e.g., logo, relevant diagram, science image) in the body text, although these are optional (but encouraged when this exists). Please read *styling rules* for individual types of content.
 
 ## Handling images
-Images for content are stored in a different repository (and not the main repo). To reference the images in the article, we upload them [bssw.io images directory](https://github.com/betterscientificsoftware/images) and then reference them from the article.
-- Add the following url. Using the "logo" class helps constrain the size of the image.
+Images for content are stored in the main `bssw.io`repository in the `images/` subdirectory.
+To reference the images in the `*.md` article file, copy the image file is to the `images/` directory and then:
+
+- Add the relative path to the image file from the `*.md` file. Using the "logo" class helps constrain the size of the image.
 ````
-< img src='<img src='https://github.com/betterscientificsoftware/images/raw/master/YOUR-IMAGE-NAME.png' class='logo' />
+< img src='<img src='../../images/YOUR-IMAGE-NAME.png' class='logo' />
 ````
 - Please ensure we have permission to use the logo/image 
 - Please ensure logo is clear and high resolution
+- Please remember to commit the image file with the `*.md` file on your git branch
+
+See  [images/README.md](https://github.com/betterscientificsoftware/bssw.io/blob/master/images/README.md) for more details.
 
 ## Metadata Section
 

--- a/docs/pages/bssw/bssw_styling_curated.md
+++ b/docs/pages/bssw/bssw_styling_curated.md
@@ -15,7 +15,7 @@ article can highlight several types of resources, including the following: book,
 
 The following figure shows different parts of a curated content article.
 
-- <img src='https://github.com/betterscientificsoftware/images/raw/master/documentation-cc-example.jpg'/>
+- <img src='https://github.com/betterscientificsoftware/bssw.io/raw/master/images/documentation-cc-example.jpg'/>
 
 The main part of the curated article consists of the (1) Deck, (2)
 Main body of the article and (3) Metadata section. The following

--- a/docs/pages/bssw/bssw_styling_originalarticles.md
+++ b/docs/pages/bssw/bssw_styling_originalarticles.md
@@ -23,14 +23,12 @@ Original articles may have deck text and/or deck images. Deck text is usually a 
  * Having deck text and a deck image in an original article are mutually exclusive.
       * A way to approximate having both is to have the deck image and then put the deck as your first (short) paragraph after the image and italicize it.
  * Please note that many times in the BSSw.io literature the deck image is also called as hero image.
- * Images for content are stored in a different repository (and not the main repo). To reference the images in the article, we upload them [bssw.io images directory](https://github.com/betterscientificsoftware/images) and then reference them from the article.
+ * Images for content are stored under the `images/` directory in the main `bssw.io` repository. To reference the images in the article, we put in a relative path (see [images/README.md](https://github.com/betterscientificsoftware/bssw.io/blob/master/images/README.md)).
  * There are some formatting tips described below for the deck images.
    - The formatting to include a deck/hero image is a bit finicky.
       * The `**Hero Image:**` tag must be followed by a blank line
-      * The image itself must be in a Markdown list item (that is, it starts with `-`)
-        ````
-           - < img src="https://github.com/betterscientificsoftware/images/raw/master/IMAGE-NAME.png" />[IMAGE TEXT]
-         ````
+      * The image itself must be in a Markdown list item (that is, it starts with `-`) <br>
+        `- < img src="../../images/IMAGE-NAME.png" />[IMAGE TEXT]`
    - Positioning of the hero image relative to the contributor and publication date metadata doesn't matter.
    
 ### Deck Attributes

--- a/images/README.md
+++ b/images/README.md
@@ -1,7 +1,5 @@
 # images
 
-**NOTE: PLEASE FOLLOW THE INSTRUCTIONS GIVEN BELOW. All new images should be uploaded to the  `bssw.io/images` directory!**
-
 This directory is for image files that will be displayed on the bssw.io site.
 
 Note that you can place an image from any location on the web, but drawing images from this images directory and assigning the proper class for an image ensures it will display consistently with other images in the site.
@@ -117,5 +115,5 @@ These are a special case. Enter the code below substituting your filename at the
 These are addressed as a text link and follow the formatting below.
 
 ```
-[WhatIs doc](../../images//filename.pdf "What is Good Documentation?")
+[WhatIs doc](../../images/filename.pdf "What is Good Documentation?")
 ```


### PR DESCRIPTION
# Description

Addresses issue #738

NOTE: The documentation for the handling of images with the the "slides" in
the Homepage.md file are kind of confusing.  I changed them to match what I
observed to actually be the behavior.  (But clearly the site generator needs
to be updated to remove the 'raw' and 'master' parts of the 'image' entries.)

## PR checklist for (internal) files not displayed on bssw.io site

*Click "Write" above and remove comment markers to see below checklist items*

* [x] Set list of Reviewers (at least one).
* [x] Add to Project [BSSw Internal].
* [x] View the modified `*.md` files as rendered in GitHub.
* [x] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.
* [x] Watch for PR check failures.
* [ ] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [ ] Ensure at least one reviewer signs off on the changes.
* [ ] Once reviewer has approved and PR check pass, then merge the PR.

<!-- Standard links below, leave these this section! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
