### PR TITLE
Updating documentation of carousel in Site/Homepage.md

### DIFF
--- a/docs/pages/bssw/bssw_content_highlighting.md
+++ b/docs/pages/bssw/bssw_content_highlighting.md
@@ -23,40 +23,38 @@ The BSSw.io frontpage contains a featured item carousel. The items, in the carou
 **Carousel format and example**
 ````
 <!---
-Slide1 L: link/image
-Slide1 R: link/image
-Slide2 L: link/image
+Slide1 L: article or image reference
+Slide1 R: article or image reference
+Slide2 L: article or image reference
 .
 .
-Slide6 R: link/image
+Slide5 R: article or image reference
 --->
 ````
 Some points to note:
-- The carousel has six `slides`, each having a left (L) and right (R) side. 
+- The carousel can have as many `slides`, as we like.  Each slide has a left (L) and right (R) side, so it can highlight two articles or an article and an accompanying image (preferred, particularly for blog articles).  We need to be careful not to have too many slides in the carousel.  Use *five* slides as a guideline.
 
 ````
 - Slide1 L: indicates 1st slide in the carousel, left side
 - Slide1 R: indicates 1st slide in the carousel, right side
 ````
-- Each side of a slide can hold (1) link to a content page or (2) an image. For example: For a blog post, left side can hold link to the blog post and right side can hold a deck image.
-- The `link` is a relative url of the article hosted on the BSSw.io site. For ex: The [article](https://bssw.io/blog_posts/give-thanks) with url `https://bssw.io/blog_posts/give-thanks` would be referred to `blog_posts/give-thanks` in the link.
-- The `image` is also the relative url to the [BSSw.io images repo](https://github.com/betterscientificsoftware/images) with a strict path. For ex: If we need to put [this image](https://github.com/betterscientificsoftware/images/blob/master/Blog_1119_seasonal.png) in the carousel, you would specify it as `images/raw/master/Blog_1119_seasonal.png`.
+- Each side of a slide can hold (1) a reference to a content page or (2) an image. For example: For a blog post, left side should reference the blog post itself and right side should reference the hero image.
+- An `article` is a relative path to the source of the article in the bssw.io repository. For ex: The [article](https://bssw.io/blog_posts/give-thanks), which corresponds to the source file `Articles/Blog/GiveThanks.md`, would be referred to as `../Articles/Blog/GiveThanks.md` in the carousel.
+- An `image` is also a relative path to the desired image. For ex: If we need to put [this image](https://github.com/betterscientificsoftware/images/blob/master/Blog_1119_seasonal.png) in the carousel, you would specify it as `../images/Blog_1119_seasonal.png`.
 
 **Carousel highlight slides example**
 ````
 <!---
-Slide1 L: blog_posts/performance-portability-and-the-exascale-computing-project
-Slide1 R: images/raw/master/Blog_1220_PerfPorta.png
-Slide2 L: blog_posts/give-thanks
-Slide2 R: images/raw/master/Blog_1119_seasonal.png
-Slide3 L: items/tips-for-producing-online-panel-discussions
-Slide3 R: images/raw/master/Resource_1120_RemotePanel.png
-Slide4 L: blog_posts/recent-successes-with-psip-on-hdf5
-Slide4 R: images/raw/master/Blog_1120_PSIP_HDF5_BlackHole.png
-Slide5 L: events/panel-year-in-review-what-have-we-learned-so-far
-Slide5 R: items/a-collection-of-resources-for-sustaining-open-source-software
-Slide6 R: items/software-and-workflow-development
-Slide6 L: items/scientific-software-bloggers-worth-following
+Slide1 L: ../Articles/Blog/BSSwFellowshipApplicationsOpen2021.md
+Slide1 R: ../images/Blog_2108_FellowsAppOpen.png
+Slide2 L: ../Articles/Blog/2021-08-registry-best-practices.md 
+Slide2 R: ../CuratedContent/ThingsYouShouldNeverDoPartI.md
+Slide3 L: ../Articles/Blog/2021-08-IntegratingInterns.md
+Slide3 R: ../images/Blog_0821_Interns.png
+Slide4 L: ../Articles/Blog/2021-07-BSSwFellows21.md
+Slide4 R: ../images/Blog_0720_Fellows.png
+Slide5 L: ../CuratedContent/SwEcosystems.md
+Slide5 R: ../CuratedContent/InclusiveNamingInitiative.md
 --->
 ````
 


### PR DESCRIPTION
The content of the "carousel" in Site/Homepage.md has changed.  This change updates the documentation to match.

This PR updates EB docs, not bssw.io content.  It resolves #1043
