### PR TITLE
Proposing a small change to the workflow

### DIFF
--- a/docs/pages/bssw/bssw_curatedworkflow.md
+++ b/docs/pages/bssw/bssw_curatedworkflow.md
@@ -71,9 +71,8 @@ each of the numbered steps in the description below.
      * Manually add to *In Progress* on the *Content Development* project board.
      * Copy details from the issue to the PR: (1) "Assignee" field to indicate EB member, 
        (2) Author name is indicated on first line. 
-     * Close the associated Issue, add comment that continued discussion will occur in the 
-       PR `#<pr-id>`, and remove the issue from the "Content Development" board. (Unless a PR was created
-       from the start instead of an Issue, see note below.)
+     * Be sure to add the Issue number (including the `#`) to the `Resolves` field in the PR.
+       This will ensure that GitHub will automatically close the issue when the PR is merged.
      * PRs that are ready to be reviewed are  moved to *Item Review*
        * Curated content PRs require one reviewer.
        * Blog articles require two reviewers.


### PR DESCRIPTION
I would like to propose this small change to our workflow.

Currently, once a PR is created, the workflow is to go to the associated issue, document the PR number and close the issue.
However, GitHub will automatically close issues linked to a PR when the PR is merged.  All you have to do is use the right language in the PR to make the link.  I've already changed the PR template so that the language is there (`Resolves #<issue-id>`).  So if people use it properly, the issue(s) will close when the PR is merged.

There are two differences from our current workflow:
1) It eliminates a manual operation that the EB member must do
2) The issue closure is delayed to when the PR is merged instead of when it is created

So there is a bit of a trade-off.  The issue stays around a little longer, but overall we have fewer manual steps.  I think it is worth it.  (And of course there is nothing to stop people from manually closing the issue anyway if they want to.)

I'd like to bring this to the EB for discussion.
