### PR TITLE
Support ordinary footnoting in wikizer_refs.py

### DIFF
--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -95,7 +95,7 @@ We hope the resources we have compiled here are useful to any readers who may be
 But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://www.nytimes.com/1998/01/25/magazine/on-language-misrule-of-thumb.html) out there to sift through as well.
 In addition, when you are seeking to learn more about any possible negative impacts of a given word or phrase, its best to seek opinions from experts *within* the groups most likely impacted.
-In other words, if a given phrase has potential negative impacts against blacks, then language experts within the black community will likely have the the most informed guidance.
+In other words, if a given phrase has potential negative impacts against blacks, then language experts within the black community will likely have the the most credible guidance.
 If a given phrase has potential negative impacts against the deaf, then language experts within the deaf community will likely have the most informed guidance.
 
 Finally, in seeking to fix inclusivity bugs, its important to take care that we don't introduce another kind of problem...excluding the use of perfectly acceptable language for no other reason than out of fear of looking bad or being labeled non-inclusive.

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -82,7 +82,7 @@ But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
 
 If you've read this far, you may be asking yourself, how do I get started?
-And, in particular, what *tooling* is available to help me find and correct inclusive language issues (a colleague on the Inclusive Naming Initiative calls these *inclusivity bugs*) in my project?
+And, in particular, what *tooling* is available to help me find and correct inclusive language issues ([Joanna Lee](https://github.com/joannalee333) a colleague on the [Inclusive Naming Initiative](https://inclusivenaming.org/) calls these *inclusivity bugs*) in my project?
 Some of the resources listed here provide some tooling.
 That said, DevOps level tooling for inclusive language is still in its infancy stages.
 

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -35,6 +35,8 @@ As HPC/CSE software developers maybe we're not doing anything nearly as momentus
 Do we really need to worry so much about inclusive language?
 If we care about our project's reach and maximizing our ability to attract and retain collaborators, developers, users or sponsors, then yes we do.
 That is because the language we use has the power to welcome others in as well as push them away.
+Anyone who has been involved in writing proposals for a sponsor that is looking to fund work in a particular area of research understands the importance of and, indeed, already has a great deal of experience adjusting the *language* used to describe their work to fit the sponsor's call.
+In other words, we all can be quite mindful of the language we use when funding is on the line.
 
 Software projects involve a lot of communication.
 As developers, we write code, comments, documentation, research papers, presentations, job postings, promotional materials, discussion posts, emails, chats, tweets and more.
@@ -70,11 +72,10 @@ Catering to any one individual's tastes and sensibilities is not what inclusive 
 The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally *excluding whole groups* of people.
 It is not about being politically correct or being the language police.
 Its about being willing to acknowledge that certain terms and phrases (and, honestly, even names, icons and logos), however common in current culture, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
-Anyone who has been involved in writing proposals for a sponsor that is looking to fund work in a particular area of research understands the importance of and already has a great deal of experience adjusting the *language* used to describe their work to fit the sponsor's call.
 
 Given the current social justice climate in which we all operate, some readers will feel that inclusive language efforts are nowhere near enough to meet the moment.
 Others will feel like such efforts are way too much.
-While we can acknowledge both prespectives, it is worth considering that [when we're accustomed to parroting the status quo, ponder more inclusive language can feel like oppression](https://www.huffpost.com/entry/when-youre-accustomed-to-privilege_b_9460662).
+While we can acknowledge both prespectives, it is worth considering that [when we're accustomed to parroting the status quo, pausing to ponder more inclusive language can feel like oppression](https://www.huffpost.com/entry/when-youre-accustomed-to-privilege_b_9460662).
 
 Ever since adopting the practice myself, there isn't a week that goes by that I don't have the experience of questioning a term or phrase I am about to use.
 I often spend a few minutes searching the web to learn more about it.

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -37,29 +37,31 @@ As developers, we write code, comments, documentation, research papers, presenta
 It is now well known that language used in [job postings](https://www.mya.com/blog/unconscious-bias-in-job-descriptions/) has the effect of biasing the respondent pool in undesireable ways.
 The more we adopt inclusive language, the more we reduce biases and create welcoming and safe spaces for all stakeholders to be their authentic selves, to be productive and to thrive.
 
-There are no words that will be acceptable to literally *every* individual.
+Inclusive *naming* is closely related to inclusive language and involves the naming of things.
+That is the *names* we choose for abstract objects of our software systems.
+A callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
+
+Do you know why we call it "Halley's Comet"?
+Halley was not the first to observe or even record it.
+Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Historical_comet_observations_in_China#Halley's_Comet) it almost 2,000 years before Halley.
+Halley, however, is believed to be the first to estimate its orbit and based on that estimation connect recorded observations from 1531, 1607 and 1682 as being the same object and then correctly predict its return in 1758.
+
+What about Pythagoras' theorem?
+Was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous and fundamental right-triangle rule?
+Much [scholarly research](https://www.researchgate.net/publication/337941217_Mathematics_in_Ancient_Egypt_Part_II) suggests he was not.
+
+Sometimes, there is no way to phrase something that will be acceptable to literally *every* individual.
 But, catering to any specific individual's tastes and sensibilities is not what inclusive language is all about.
-The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally excluding whole groups of people.
+The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally *excluding whole groups* of people.
 It is not about being politically correct or being the language police.
-Its about being willing to acknowledge that poorly chosen terms and phrases can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
+Its about being willing to acknowledge that poorly chosen terms and phrases, even if part of common vernacular, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
 Many terms and phrases we often use are simply unconcsiously repeating the words of others.
 That can be dangerous if one is not mindful of either the meaning, context or history of the term.
 Do any readers know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
 
-Inclusive *naming* is closely related to inclusive language and involves the naming of things.
-That is the *names* we choose for abstract objects of our software systems.
-A callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
-Do you know why we call it "Halley's Comet"?
-Halley was not the first to observe or even record it.
-Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Historical_comet_observations_in_China#Halley's_Comet) it almost 2,000 years before Halley.
-Halley, however, is believed to be the first to estimate its orbit and based on that estimation connect recorded observations from 1531, 1607 and 1682 as being the same object and then correctly predict its return in 1758.
-What about Pythagoras' theorem?
-Was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous right-triangle rule, a2+b2=c2?
-
-New thinking cap. What does the practice look like. 
-
-Changing code vs. changing non-code artifacts.
+Ever since adopting the practice of being more inclusive in my own language, there isn't a week that goes by that I don't have the experience of questioning myself about why I am about to write or speak a given phrase.
+I often spend a few minutes searching the web to learn more about it before I move ahead as planned to select different words.
 
 <!--
 https://www.cfr.org/blog/woman-moon-and-equality-earth

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -9,7 +9,7 @@ If we knew such phrases had their roots in oppressive or genocidal history, or i
 
 Resource information | Details
 :--- | :--- 
-Article title  | [Inclusive Naming Initiative](https://inclusivenaming.org)
+Article title  | [Inclusive Naming Initiative](https://bssw.io/items/inclusive-naming-initiative)
 &nbsp; | [Conscious Language](https://github.com/conscious-lang/conscious-lang-docs)
 &nbsp; | [Plain Language](https://www.plainlanguage.gov/)
 &nbsp; | [Terminology, Power and Oppressive Language](https://tools.ietf.org/id/draft-knodel-terminology-00.html)
@@ -21,57 +21,50 @@ Focus | Inclusive Practices
 
 When taking the first steps on the Moon, Armstrong said "This is a small step for a *man* but a giant leap for *man*kind."
 Later that same Moonwalk, he said..."It is a great honor...to be here representing...*men* of peaceable nations, *men* with an interest and a curiosity, and *men* with a vision for the future."
+
 Regardless of how common-place any given turn of phrase is or may have been for its time, the example demonstrates how the language we use can wind up excluding others.
-To help skeptics of the importance of inclusive language walk in others shoes, imagine if the first mission to Mars is a crew of all Black, Muslim women and the first to set foot on Mars says "This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."
+To help skeptics empathize, imagine if the first mission to Mars is a crew of all Black, Muslim women and the first to set foot on Mars says "This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."
 
-Ok, as HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on some other celestial body.
+Ok, as HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on another planet.
 Do we really need to worry so much about inclusive language?
-Site job posting, productivity, list persons who might want to reach out too.
-
-
-
-https://www.cfr.org/blog/woman-moon-and-equality-earth
-
-
-
-
-
-https://www.businessinsider.com/apollo-11-women-made-moon-landing-possible-2019-7#frances-poppy-northcutt-was-the-first-woman-in-mission-control-at-nasa-she-helped-make-sure-the-apollo-astronauts-return-trajectory-calculations-were-sound-so-that-theyd-get-home-safely-10
-
-https://floridapress.blog/2020/10/30/the-women-behind-the-apollo-space-suit/
-
-While we recognize that there are sometimes no words that will be found acceptable to literally *every* individual, the goal of inclusive language is to reduce the use of language that winds up uniformally excluding whole groups of people.
+If we care about maximizing our project's ability to attract and retain potential collaborators, developers, users and sponsors, then yes we do.
+That is because the language we use has the power to welcome others in as well as push them away.
 
 Software projects involve a lot of communication.
 As developers, we write code, comments, documentation, research papers, presentations, job postings, promotional materials, discussion posts, emails, chats, tweets and more.
 Just look at how much communication can be associated with a single [bug report](https://github.com/visit-dav/visit/issues/4908).
 
-The language we use has the power to welcome people in and also push them away.
-For example, it is now well known that language used in [job postings](https://www.mya.com/blog/unconscious-bias-in-job-descriptions/) has the effect of biasing respondent pool in undesireable ways. 
-The more we adopt inclusive language, the more we reduce biases... create safe and welcoming space for others to participate.
+It is now well known that language used in [job postings](https://www.mya.com/blog/unconscious-bias-in-job-descriptions/) has the effect of biasing the respondent pool in undesireable ways.
+The more we adopt inclusive language, the more we reduce biases and create welcoming and safe spaces for all stakeholders to bring their authentic selves to work and to thrive and be productive.
 
-Not about being PC or language police.
-Its about identifying terms and phrases, ... often the alternatives are
+While we recognize that there are sometimes no words that will be found acceptable to literally *every* individual, the goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally excluding whole groups of people.
+It is not about being politically correct or being the language police.
+Its about being willing to evaluate whether a given term or phrase is unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
 Many terms and phrases we often use are simply unconcsiously repeating the words of others.
 That can be dangerous if one does not know either the meaning, context or history of the term.
+Do any readers know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
 
-Do you know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
+A specific aspect of inclusive language in software involves the *naming* of things.
+That is the *names* we choose for abstract objects of our software systems.
+There may be no other human activity that involves the naming of new things as much as software development.
+We tend to get particularly attached to names, often without any regard for whether the name is accurate reflection of function.
 
-gendered terminology
-
-A specific aspect of language is naming.
-we get particularly attached to names
-
-
-More broadly, did you ever wonder whether Edmond Halley was indeed to first ever person to observe, record and ultimately predict the return of the comet that bares is name?
+More broadly, did you ever wonder whether Edmond Halley was indeed to first ever person to observe, record and ultimately predict the return of the comet that bares his name?
 What about Pythagoras' theorem?
 Was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous right-triangle rule, a2+b2=c2?
 
-There is probably no other human activity that involves the naming of new things as much as software development.
 There is power in naming and with great power, comes great responsibility.
 The names we use in our code and its associated artifacts (PR reviews, documentation, presentations, social media posts, etc.) are often shaped by our culture.
 
 New thinking cap. What does the practice look like. 
 
 Changing code vs. changing non-code artifacts.
+
+<!--
+https://www.cfr.org/blog/woman-moon-and-equality-earth
+
+https://www.businessinsider.com/apollo-11-women-made-moon-landing-possible-2019-7#frances-poppy-northcutt-was-the-first-woman-in-mission-control-at-nasa-she-helped-make-sure-the-apollo-astronauts-return-trajectory-calculations-were-sound-so-that-theyd-get-home-safely-10
+
+https://floridapress.blog/2020/10/30/the-women-behind-the-apollo-space-suit/
+-->

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -35,9 +35,9 @@ That is because the language we use has the power to welcome others in as well a
 Software projects involve a lot of communication.
 As developers, we write code, comments, documentation, research papers, presentations, job postings, promotional materials, discussion posts, emails, chats, tweets and more.
 It is now well known that language used in [job postings](https://www.mya.com/blog/unconscious-bias-in-job-descriptions/) has the effect of biasing the respondent pool in undesireable ways.
-The more we adopt inclusive language, the more we reduce biases and create welcoming and safe spaces for all stakeholders to be their authentic selves, to be productive and to thrive.
+The more we adopt inclusive language, the more we reduce biases and create welcoming and safe spaces for all participants to be their authentic selves, to be productive and to thrive.
 
-Inclusive *naming* is closely related to inclusive language and involves the naming of things.
+Inclusive *naming* is closely related to inclusive language but focuses primarily on the naming of things.
 That is the *names* we choose for abstract objects of our software systems.
 A callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
 For example, was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous and fundamental right-triangle rule?
@@ -57,14 +57,14 @@ How might a black person feel reading that existing users will be [*grandfathere
 How might a neuro-diverse person feel about being tasked to add [*sanity checks*](https://gist.github.com/seanmhanson/fe370c2d8bd2b3228680e38899baf5cc) to a software package's test suite?
 
 Sometimes, there is no way to phrase something that will be acceptable to literally *every* individual.
-Nor, should we aim for that.
-Catering to any specific individual's tastes and sensibilities is not what inclusive language is all about.
+Nor, should we be aiming for that.
+Catering to any one individual's tastes and sensibilities is not what inclusive language is all about.
 The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally *excluding whole groups* of people.
 It is not about being politically correct or being the language police.
 Its about being willing to acknowledge that poorly chosen terms and phrases, however common in current vernacular, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
-Ever since adopting the practice of being more inclusive in my own language, there isn't a week that goes by that I don't have the experience of questioning myself about why I am about to write or speak a given phrase.
-I often spend a few minutes searching the web to learn more about it before I choose to either move ahead as planned or select different words.
+Ever since adopting the practice of being more inclusive in my own language, there isn't a week that goes by that I don't have the experience of questioning why I am about to write or speak a given phrase.
+I often spend a few minutes searching the web to learn more about it (including terms and phrases I have used many times before I choose to either move ahead as planned or select different words.
 We hope the resources we have compiled here are useful to anyone who is similarly inclined.
 But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -82,8 +82,8 @@ But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
 
 If you've read this far, you may be asking yourself, how do I get started?
-And, in particular, what *tooling* is available to help me find and correct inclusive language issues ([Joanna Lee](https://github.com/joannalee333) a colleague on the [Inclusive Naming Initiative](https://inclusivenaming.org/) calls these *inclusivity bugs*) in my project?
-Some of the resources listed here provide some tooling.
+I would suggest reading some of the resources offered here, especially [Plain Language](https://www.plainlanguage.gov/), [Google inclusive style](https://developers.google.com/style/inclusive-documentation), and [MicroSoft's Bias Free Communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication).
+In particular, if you are looking for *tooling* to help find and correct inclusive language issues ([Joanna Lee](https://github.com/joannalee333), a colleague on the [Inclusive Naming Initiative](https://inclusivenaming.org/), calls these *inclusivity bugs*) in your project, some of the resources listed here provide some tooling.
 That said, DevOps level tooling for inclusive language is still in its infancy stages.
 
 <sup>1</sup>The comet is named for Halley because it is believed he was the first to have estimated its orbit and based on that connected recorded observations from 1531, 1607 and 1682 as being the same celestial object from which he correctly predicted its return in 1758.

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -24,7 +24,7 @@ When fist stepping on the Moon, Armstrong said *"This is a small step for a **ma
 Later that same Moonwalk, [he said](https://www.presidency.ucsb.edu/documents/telephone-conversation-with-the-apollo-11-astronauts-the-moon), *"It is a great honor...to be here representing...**men** of peaceable nations, **men** with an interest and a curiosity, and **men** with a vision for the future."*
 That sure doesn't read now nor did it sound at the time very much like space exploration included women.
 
-Regardless of how common-place any given customary expression or turn of phrase is or may have been for its time, the example demonstrates how the language we use can wind up excluding whole groups of people.
+Regardless of how common-place any manner of speaking or turn of phrase is or may have been for its time, the example demonstrates how the language we use can manifest bias and wind up excluding whole groups of people.
 To help skeptics empathize, imagine if instead of a crew of all white, Christian men the first mission to Mars is crewed by all black, Muslim women and the first to walk on Mars says something like *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
 
 As HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on another planet.
@@ -41,6 +41,7 @@ Inclusive *naming* is closely related to inclusive language but focuses primaril
 That is the *names* we choose for abstract objects of our software systems.
 A callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
 Was Edmund Halley the first to observe and record [the comet](https://www.space.com/19878-halleys-comet.html) that bares his name?<sup>1</sup>
+Certainly not.
 Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Historical_comet_observations_in_China#Halley's_Comet) it almost 2,000 years earlier.
 Was Pythagoras the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to discover and write down the rule we know as the Pythagorean theorem?
 Plenty of [scholarly research](https://www.researchgate.net/publication/337941217_Mathematics_in_Ancient_Egypt_Part_II) says he was not.
@@ -59,10 +60,13 @@ The goal of inclusive language is to reduce the use of terms and phrases that wi
 It is not about being politically correct or being the language police.
 Its about being willing to acknowledge that certain terms and phrases (and, honestly, even names, icons and logos), however common in current culture, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
+Given the current social justice climate in which we all operate, some readers will feel that inclusive language efforts are nowhere near enough to meet the moment.
+Others will feel like such efforts are way too much.
+While we can acknowledge both prespectives, it is worth considering that when we're accustomed to parroting the status quo, striving for more inclusive language can feel like oppression.
+
 Ever since adopting the practice myself, there isn't a week that goes by that I don't have the experience of questioning a term or phrase I am about to use.
 I often spend a few minutes searching the web to learn more about it.
 This includes terms and phrases I have used many times before without really thinking about it.
-
 We hope the resources we have compiled here are useful to any readers who may be similarly inclined.
 But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -37,20 +37,23 @@ As developers, we write code, comments, documentation, research papers, presenta
 It is now well known that language used in [job postings](https://www.mya.com/blog/unconscious-bias-in-job-descriptions/) has the effect of biasing the respondent pool in undesireable ways.
 The more we adopt inclusive language, the more we reduce biases and create welcoming and safe spaces for all stakeholders to be their authentic selves, to be productive and to thrive.
 
-Sometimes, there are no words that will be acceptable to literally *every* individual.
-But, catering to specific individuals tastes or sensibilities is not what inclusive language is all about.
+There are no words that will be acceptable to literally *every* individual.
+But, catering to any specific individual's tastes and sensibilities is not what inclusive language is all about.
 The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally excluding whole groups of people.
 It is not about being politically correct or being the language police.
-Its about being willing to acknowledge that poorly chosen terms and phrase can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
+Its about being willing to acknowledge that poorly chosen terms and phrases can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
 Many terms and phrases we often use are simply unconcsiously repeating the words of others.
 That can be dangerous if one is not mindful of either the meaning, context or history of the term.
 Do any readers know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
 
-Inclusive *naming* is closely associated with inclusive language and involves the naming of things.
+Inclusive *naming* is closely related to inclusive language and involves the naming of things.
 That is the *names* we choose for abstract objects of our software systems.
-We tend to get particularly attached to names, often without any regard for accuracy in source or function.
-Did you ever wonder whether Edmond Halley was indeed to first person to observe, record and ultimately predict the return of the comet that bares his name?
+A callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
+Do you know why we call it "Halley's Comet"?
+Halley was not the first to observe or even record it.
+Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Historical_comet_observations_in_China#Halley's_Comet) it almost 2,000 years before Halley.
+Halley, however, is believed to be the first to estimate its orbit and based on that estimation connect recorded observations from 1531, 1607 and 1682 as being the same object and then correctly predict its return in 1758.
 What about Pythagoras' theorem?
 Was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous right-triangle rule, a2+b2=c2?
 

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -18,6 +18,10 @@ Article title  | [Inclusive Naming Initiative](https://bssw.io/items/inclusive-n
 &nbsp; | [MicroSoft's Bias Free Communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
 &nbsp; | [Say This, Not That](https://thediversitymovement.com/say-this-not-that-a-guide-for-inclusive-language/)
 &nbsp; | [Effectively Naming Software Thingies](https://medium.com/@rabinovichsagi/effectively-naming-software-thingies-fcea9d78a699)
+&nbsp; | [8 Resources to Ensure You're Using Inclusive Language](https://blog.hubspot.com/marketing/tools-inclusive-language)
+&nbsp; | [Online Tools to Check Your Writing for Empathy and Inclusivity](https://www.fastcompany.com/3053713/these-7-online-tools-check-your-writing-for-empathy-and-inclusivity)
+&nbsp; | [MicroSoft Office Inclusive Language Features](https://thenextweb.com/news/microsoft-office-can-help-you-write-with-inclusive-language-heres-how)
+&nbsp; | [Inclusive Lint](https://github.com/inclusivelint/inclusivelint)
 Focus | Inclusive Practices
 
 When fist stepping on the Moon, Armstrong said *"This is a small step for a **man** but a giant leap for **man**kind."*
@@ -46,12 +50,18 @@ Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Histor
 Was Pythagoras the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to discover and write down the rule we know as the Pythagorean theorem?
 Plenty of [scholarly research](https://www.researchgate.net/publication/337941217_Mathematics_in_Ancient_Egypt_Part_II) says he was not.
 
-Many terms and phrases we commonly use are simply unconcsiously following informal precedent set by others.
-That can be dangerous if one is not mindful of the meaning, history or impact of the term upon others.
+For many terms and phrases we commonly use, we are simply unconcsiously parroting others.
+That can be dangerous if one is not mindful of the meaning, history or impact of a term.
 Do any readers know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
 How might a women feel reading documentation that constantly refers to the user as [*he*, *his* or *him*](https://www.washingtonpost.com/world/2019/12/15/guide-how-gender-neutral-language-is-developing-around-world/)?
 How might a black person feel reading that existing users will be [*grandfathered in*](https://www.npr.org/sections/codeswitch/2013/10/21/239081586/the-racial-history-of-the-grandfather-clause) when the software license terms are changed?
 How might a neuro-diverse person feel about being tasked to add [*sanity checks*](https://gist.github.com/seanmhanson/fe370c2d8bd2b3228680e38899baf5cc) to a software package's test suite?
+
+By the way, do readers recognize any bias manifested in the preceding questions?
+Its subtle but worth mentioning.
+The way these questions are worded suggest that only women would care about documentation that is laden with male pronouns or that only black people would care about language derived out of oppresive practices or that only neuro-diverse people would care about language associated with a state of mind.
+The truth is, we all (*should*) care.
+And, to use language that suggests otherwise is, well, not inclusive.
 
 There is no way to phrase something that will be acceptable to literally *every* individual.
 And, there is no reason we should be aiming for that either.
@@ -70,6 +80,11 @@ This includes terms and phrases I have used many times before without really thi
 We hope the resources we have compiled here are useful to any readers who may be similarly inclined.
 But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
+
+If you've read this far, you may be asking yourself, how do I get started?
+And, in particular, what *tooling* is available to help me find and correct inclusive language issues (a colleague on the Inclusive Naming Initiative calls these *inclusivity bugs*) in my project?
+Some of the resources listed here provide some tooling.
+That said, DevOps level tooling for inclusive language is still in its infancy stages.
 
 <sup>1</sup>The comet is named for Halley because it is believed he was the first to have estimated its orbit and based on that connected recorded observations from 1531, 1607 and 1682 as being the same celestial object from which he correctly predicted its return in 1758.
 

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -1,4 +1,4 @@
-# How the Language We Use can Lead to Inclusivity Bugs
+# Inclusivity Bugs and the Language We Use
 <!--deck text start-->
 If we knew terms and phrases we commonly use such as, for example, *sanity check*,  *tipping point*, or *grandfathered* had the effect of normalizing or perpetuating historical systemic biases, would we still use them?
 <!--deck text end-->
@@ -23,12 +23,14 @@ Article title  | [Inclusive Naming Initiative](https://bssw.io/items/inclusive-n
 &nbsp; | [MicroSoft Office Inclusive Language Features](https://thenextweb.com/news/microsoft-office-can-help-you-write-with-inclusive-language-heres-how)
 &nbsp; | [Inclusive Lint](https://github.com/inclusivelint/inclusivelint)
 &nbsp; | [Gender Inclusive Language Manual](https://www.nato.int/nato_static_fl2014/assets/pictures/images_mfu/2021/5/pdf/210514-GIL-Manual_en.pdf)
+&nbsp; | [Inclusive Language And Design In Tech](https://www.forbes.com/sites/carolinamilanesi/2021/06/29/the-importance-of-inclusive-language-and-design-in-tech)
 Focus | Inclusive Practices
 
 When fist stepping on the Moon, Armstrong said *"This is a small step for a **man** but a giant leap for **man**kind."*
 Later that same Moonwalk, [he said](https://www.presidency.ucsb.edu/documents/telephone-conversation-with-the-apollo-11-astronauts-the-moon), *"It is a great honor...to be here representing...**men** of peaceable nations, **men** with an interest and a curiosity, and **men** with a vision for the future."*
+
 That sure doesn't read now nor did it sound at the time very much like space exploration included women.
-[Joanna Lee](https://github.com/joannalee333), a contributor to the [Inclusive Naming Initiative](https://inclusivenaming.org/), calls the use of language like this in software projects *inclusivity bugs*).
+[Joanna Lee](https://github.com/joannalee333), a contributor to the [Inclusive Naming Initiative](https://inclusivenaming.org/), calls the use of language that excludes whole groups of people like this *inclusivity bugs*.
 
 Regardless of how common-place any manner of speaking or turn of phrase is or may have been for its time, the example demonstrates how the language we use can manifest bias and wind up excluding whole groups of people.
 To help skeptics empathize, imagine if instead of a crew of all white, Christian men as the first Apollo mission was (maybe all Apollo missions), the first mission to Mars is crewed by all black, Muslim women and the first to walk on Mars says something like *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
@@ -77,11 +79,6 @@ The goal of inclusive language is to reduce the use of terms and phrases that wi
 It is not about being politically correct or being the language police.
 Its about being willing to acknowledge that certain terms and phrases (and, honestly, even names, icons and logos), however common in current culture, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
-Given the current social justice climate in which we all operate, some readers will feel that inclusive language efforts are nowhere near enough to meet the moment and are really a [distraction](https://www.wired.com/story/tech-confronts-use-labels-master-slave/) from bigger issues.
-Its hard to argue with that.
-Nonetheless, others will feel like such efforts are way too much.
-While we can acknowledge both prespectives, it is worth considering that [when we're accustomed to parroting the status quo, pausing to be more inclusive might feel like oppression](https://www.huffpost.com/entry/when-youre-accustomed-to-privilege_b_9460662).
-
 If you've read this far, you may be asking yourself, how do I get started?
 We suggest reading some of the resources listed here, especially [Plain Language](https://www.plainlanguage.gov/), [Google inclusive style](https://developers.google.com/style/inclusive-documentation), and [MicroSoft's Bias Free Communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication).
 In particular, if you are looking for *tooling* to help alert you to inclusive language issues, some of the resources listed here provide tooling as a web service.
@@ -95,7 +92,7 @@ We hope the resources we have compiled here are useful to any readers who may be
 But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://www.nytimes.com/1998/01/25/magazine/on-language-misrule-of-thumb.html) out there to sift through as well.
 In addition, when you are seeking to learn more about any possible negative impacts of a given word or phrase, its best to seek opinions from experts *within* the groups most likely impacted.
-In other words, if a given phrase has potential negative impacts against blacks, then language experts within the black community will likely have the the most credible guidance.
+In other words, if a given phrase has potential negative impacts against blacks, then language experts within the black community will likely have the the most authoritative guidance.
 If a given phrase has potential negative impacts against the deaf, then language experts within the deaf community will likely have the most informed guidance.
 
 Finally, in seeking to fix inclusivity bugs, its important to take care that we don't introduce another kind of problem...excluding the use of perfectly acceptable language for no other reason than out of fear of looking bad or being labeled non-inclusive.
@@ -106,7 +103,13 @@ But, there is much less agreement, notably even within the black community, abou
 There are many uses of *master* that have no historical roots in oppresive or genocidal systems.
 These include such terms as *mastermind*, *postmaster*, *master key*, *master recording*, achieving *mastery* of a skill and even common tech terms like *webmaster* and *scrum master*.
 This issue garnered much attention when GitHub [announced](https://www.vice.com/en/article/k7qbyv/github-to-remove-masterslave-terminology-from-its-platform) it would change its *default* branch name (which most users simply adopt without question) from *master* to *main*.
-While this was a welcome change, its worth pointing out that the *default* language of a widely used resource such as git represents a massive proliferation potential and is a qualitatively different situation than the choices individual projects make.
+In that move it is worth pointing out that the *default* language of a widely used resource such as `git` is a significantly greater proliferation potential and represents a qualitatively different situation than the choices individual projects make.
+Furthermore, no project is prevented from using *master* as a `git` branch name if they choose.
+
+Given the current social justice climate in which we all operate, some readers will feel that inclusive language efforts are nowhere near enough to meet the moment and are really just a [distraction](https://www.wired.com/story/tech-confronts-use-labels-master-slave/) from bigger issues.
+Its hard to argue with that.
+Nonetheless, others will feel like such efforts go way too far.
+While we can acknowledge both prespectives exist, it is worth remembering that [when we're accustomed to parroting the status quo, pausing to be more inclusive feels like oppression](https://www.huffpost.com/entry/when-youre-accustomed-to-privilege_b_9460662).
 
 <sup>1</sup>The comet is named for Halley because it is believed he was the first to have estimated its orbit and based on that connected recorded observations from 1531, 1607 and 1682 as being the same celestial object from which he correctly predicted its return in 1758.
 

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -1,0 +1,77 @@
+# Inclusive Language Resources
+<!--deck text start-->
+Phrases like *sanity check*,  *tipping point*, or *grandfathered in* are not unheard of in software projects.
+If we knew such phrases had their roots in oppressive or genocidal history, or if we knew they had the effect of normalizing or perpetuating historical injustices, would we still use them?
+<!--deck text end-->
+
+#### Contributed by [Mark C. Miller](https://github.com/markcmiller86 "Mark C. Miller GitHub Profile")
+#### Publication date: October 14, 2021
+
+Resource information | Details
+:--- | :--- 
+Article title  | [Inclusive Naming Initiative](https://inclusivenaming.org)
+&nbsp; | [Conscious Language](https://github.com/conscious-lang/conscious-lang-docs)
+&nbsp; | [Plain Language](https://www.plainlanguage.gov/)
+&nbsp; | [Terminology, Power and Oppressive Language](https://tools.ietf.org/id/draft-knodel-terminology-00.html)
+&nbsp; | [Software Developer Diversity and Inclusion](https://sddiproject.org/)
+&nbsp; | [The Open Source Way](https://www.theopensourceway.org/)
+&nbsp; | [Google inclusive style](https://developers.google.com/style/inclusive-documentation)
+&nbsp; | [MicroSoft's Bias Free Communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
+Focus | Inclusive Practices
+
+When taking the first steps on the Moon, Armstrong said "This is a small step for a *man* but a giant leap for *man*kind."
+Later that same Moonwalk, he said..."It is a great honor...to be here representing...*men* of peaceable nations, *men* with an interest and a curiosity, and *men* with a vision for the future."
+Regardless of how common-place any given turn of phrase is or may have been for its time, the example demonstrates how the language we use can wind up excluding others.
+To help skeptics of the importance of inclusive language walk in others shoes, imagine if the first mission to Mars is a crew of all Black, Muslim women and the first to set foot on Mars says "This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."
+
+Ok, as HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on some other celestial body.
+Do we really need to worry so much about inclusive language?
+Site job posting, productivity, list persons who might want to reach out too.
+
+
+
+https://www.cfr.org/blog/woman-moon-and-equality-earth
+
+
+
+
+
+https://www.businessinsider.com/apollo-11-women-made-moon-landing-possible-2019-7#frances-poppy-northcutt-was-the-first-woman-in-mission-control-at-nasa-she-helped-make-sure-the-apollo-astronauts-return-trajectory-calculations-were-sound-so-that-theyd-get-home-safely-10
+
+https://floridapress.blog/2020/10/30/the-women-behind-the-apollo-space-suit/
+
+While we recognize that there are sometimes no words that will be found acceptable to literally *every* individual, the goal of inclusive language is to reduce the use of language that winds up uniformally excluding whole groups of people.
+
+Software projects involve a lot of communication.
+As developers, we write code, comments, documentation, research papers, presentations, job postings, promotional materials, discussion posts, emails, chats, tweets and more.
+Just look at how much communication can be associated with a single [bug report](https://github.com/visit-dav/visit/issues/4908).
+
+The language we use has the power to welcome people in and also push them away.
+For example, it is now well known that language used in [job postings](https://www.mya.com/blog/unconscious-bias-in-job-descriptions/) has the effect of biasing respondent pool in undesireable ways. 
+The more we adopt inclusive language, the more we reduce biases... create safe and welcoming space for others to participate.
+
+Not about being PC or language police.
+Its about identifying terms and phrases, ... often the alternatives are
+
+Many terms and phrases we often use are simply unconcsiously repeating the words of others.
+That can be dangerous if one does not know either the meaning, context or history of the term.
+
+Do you know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
+
+gendered terminology
+
+A specific aspect of language is naming.
+we get particularly attached to names
+
+
+More broadly, did you ever wonder whether Edmond Halley was indeed to first ever person to observe, record and ultimately predict the return of the comet that bares is name?
+What about Pythagoras' theorem?
+Was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous right-triangle rule, a2+b2=c2?
+
+There is probably no other human activity that involves the naming of new things as much as software development.
+There is power in naming and with great power, comes great responsibility.
+The names we use in our code and its associated artifacts (PR reviews, documentation, presentations, social media posts, etc.) are often shaped by our culture.
+
+New thinking cap. What does the practice look like. 
+
+Changing code vs. changing non-code artifacts.

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -1,7 +1,6 @@
 # Inclusive Language Resources
 <!--deck text start-->
-Phrases like *sanity check*,  *tipping point*, or *grandfathered in* are not unheard of in software projects.
-If we knew such phrases had their roots in oppressive or genocidal history, or if we knew they had the effect of normalizing or perpetuating historical injustices, would we still use them?
+If we knew terms and phrases we commonly use such as, for example, *sanity check*,  *tipping point*, or *grandfathered* had the effect of normalizing or perpetuating historical systemic biases, would we still use them?
 <!--deck text end-->
 
 #### Contributed by [Mark C. Miller](https://github.com/markcmiller86 "Mark C. Miller GitHub Profile")
@@ -21,15 +20,16 @@ Article title  | [Inclusive Naming Initiative](https://bssw.io/items/inclusive-n
 &nbsp; | [Effectively Naming Software Thingies](https://medium.com/@rabinovichsagi/effectively-naming-software-thingies-fcea9d78a699)
 Focus | Inclusive Practices
 
-When taking the first steps on the Moon, Armstrong said *"This is a small step for a **man** but a giant leap for **man**kind."*
+When fist stepping on the Moon, Armstrong said *"This is a small step for a **man** but a giant leap for **man**kind."*
 Later that same Moonwalk, [he said](https://www.presidency.ucsb.edu/documents/telephone-conversation-with-the-apollo-11-astronauts-the-moon), *"It is a great honor...to be here representing...**men** of peaceable nations, **men** with an interest and a curiosity, and **men** with a vision for the future."*
+That sure doesn't read now nor did it sound at the time very much like space exploration included women.
 
-Regardless of how common-place any given turn of phrase is or may have been for its time, the example demonstrates how the language we use can wind up excluding whole groups of people.
-To help skeptics empathize, imagine if the first mission to Mars is a crew of all Black, Muslim women and the first to set foot on Mars says something like *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
+Regardless of how common-place any given customary expression or turn of phrase is or may have been for its time, the example demonstrates how the language we use can wind up excluding whole groups of people.
+To help skeptics empathize, imagine if instead of a crew of all white, Christian men the first mission to Mars is crewed by all black, Muslim women and the first to walk on Mars says something like *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
 
-Ok, as HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on another planet.
+As HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on another planet.
 Do we really need to worry so much about inclusive language?
-If we care about maximizing our project's ability to attract and retain potential collaborators, developers, users or sponsors, then yes we do.
+If we care about our project's reach and maximizing our ability to attract and retain collaborators, developers, users or sponsors, then yes we do.
 That is because the language we use has the power to welcome others in as well as push them away.
 
 Software projects involve a lot of communication.
@@ -40,35 +40,34 @@ The more we adopt inclusive language, the more we reduce biases and create welco
 Inclusive *naming* is closely related to inclusive language but focuses primarily on the naming of things.
 That is the *names* we choose for abstract objects of our software systems.
 A callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
-For example, was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous and fundamental right-triangle rule?
-There is plenty of [scholarly research](https://www.researchgate.net/publication/337941217_Mathematics_in_Ancient_Egypt_Part_II) that suggests he was not.
-<!---
-Do you know why we call it "Halley's Comet"?
-Halley was not the first to observe or even record it.
-Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Historical_comet_observations_in_China#Halley's_Comet) it almost 2,000 years before Halley.
-Halley, however, is believed to be the first to estimate its orbit and based on that estimation connect recorded observations from 1531, 1607 and 1682 as being the same object and then correctly predict its return in 1758.
--->
+Was Edmund Halley the first to observe and record [the comet](https://www.space.com/19878-halleys-comet.html) that bares his name?<sup>1</sup>
+Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Historical_comet_observations_in_China#Halley's_Comet) it almost 2,000 years earlier.
+Was Pythagoras the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to discover and write down the rule we know as the Pythagorean theorem?
+Plenty of [scholarly research](https://www.researchgate.net/publication/337941217_Mathematics_in_Ancient_Egypt_Part_II) says he was not.
 
-Many terms and phrases we often use are simply unconcsiously following precedent set by others before us.
-That can be dangerous if one is not mindful of either the meaning, history or impact of the term upon others.
+Many terms and phrases we commonly use are simply unconcsiously following informal precedent set by others.
+That can be dangerous if one is not mindful of the meaning, history or impact of the term upon others.
 Do any readers know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
 How might a women feel reading documentation that constantly refers to the user as [*he*, *his* or *him*](https://www.washingtonpost.com/world/2019/12/15/guide-how-gender-neutral-language-is-developing-around-world/)?
 How might a black person feel reading that existing users will be [*grandfathered in*](https://www.npr.org/sections/codeswitch/2013/10/21/239081586/the-racial-history-of-the-grandfather-clause) when the software license terms are changed?
 How might a neuro-diverse person feel about being tasked to add [*sanity checks*](https://gist.github.com/seanmhanson/fe370c2d8bd2b3228680e38899baf5cc) to a software package's test suite?
 
-Sometimes, there is no way to phrase something that will be acceptable to literally *every* individual.
-Nor, should we be aiming for that.
+There is no way to phrase something that will be acceptable to literally *every* individual.
+And, there is no reason we should be aiming for that either.
 Catering to any one individual's tastes and sensibilities is not what inclusive language is all about.
 The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally *excluding whole groups* of people.
 It is not about being politically correct or being the language police.
-Its about being willing to acknowledge that poorly chosen terms and phrases, however common in current vernacular, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
+Its about being willing to acknowledge that certain terms and phrases (and, honestly, even names, icons and logos), however common in current culture, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
-Ever since adopting the practice of being more inclusive in my own language, there isn't a week that goes by that I don't have the experience of questioning why I am about to write or speak a given phrase.
+Ever since adopting the practice myself, there isn't a week that goes by that I don't have the experience of questioning a term or phrase I am about to use.
 I often spend a few minutes searching the web to learn more about it.
-This includes terms and phrases I have used many times before.
+This includes terms and phrases I have used many times before without really thinking about it.
+
 We hope the resources we have compiled here are useful to any readers who may be similarly inclined.
 But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
+
+<sup>1</sup>The comet is named for Halley because it is believed he was the first to have estimated its orbit and based on that connected recorded observations from 1531, 1607 and 1682 as being the same celestial object from which he correctly predicted its return in 1758.
 
 <!--
 https://www.cfr.org/blog/woman-moon-and-equality-earth

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -64,8 +64,9 @@ It is not about being politically correct or being the language police.
 Its about being willing to acknowledge that poorly chosen terms and phrases, however common in current vernacular, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
 Ever since adopting the practice of being more inclusive in my own language, there isn't a week that goes by that I don't have the experience of questioning why I am about to write or speak a given phrase.
-I often spend a few minutes searching the web to learn more about it (including terms and phrases I have used many times before I choose to either move ahead as planned or select different words.
-We hope the resources we have compiled here are useful to anyone who is similarly inclined.
+I often spend a few minutes searching the web to learn more about it.
+This includes terms and phrases I have used many times before.
+We hope the resources we have compiled here are useful to any of our readers are are similarly inclined.
 But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
 

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -1,4 +1,4 @@
-# Inclusive Language Resources
+# How the Language We Use can Lead to Inclusivity Bugs
 <!--deck text start-->
 If we knew terms and phrases we commonly use such as, for example, *sanity check*,  *tipping point*, or *grandfathered* had the effect of normalizing or perpetuating historical systemic biases, would we still use them?
 <!--deck text end-->
@@ -22,30 +22,35 @@ Article title  | [Inclusive Naming Initiative](https://bssw.io/items/inclusive-n
 &nbsp; | [Online Tools to Check Your Writing for Empathy and Inclusivity](https://www.fastcompany.com/3053713/these-7-online-tools-check-your-writing-for-empathy-and-inclusivity)
 &nbsp; | [MicroSoft Office Inclusive Language Features](https://thenextweb.com/news/microsoft-office-can-help-you-write-with-inclusive-language-heres-how)
 &nbsp; | [Inclusive Lint](https://github.com/inclusivelint/inclusivelint)
+&nbsp; | [Gender Inclusive Language Manual](https://www.nato.int/nato_static_fl2014/assets/pictures/images_mfu/2021/5/pdf/210514-GIL-Manual_en.pdf)
 Focus | Inclusive Practices
 
 When fist stepping on the Moon, Armstrong said *"This is a small step for a **man** but a giant leap for **man**kind."*
 Later that same Moonwalk, [he said](https://www.presidency.ucsb.edu/documents/telephone-conversation-with-the-apollo-11-astronauts-the-moon), *"It is a great honor...to be here representing...**men** of peaceable nations, **men** with an interest and a curiosity, and **men** with a vision for the future."*
 That sure doesn't read now nor did it sound at the time very much like space exploration included women.
+[Joanna Lee](https://github.com/joannalee333), a contributor to the [Inclusive Naming Initiative](https://inclusivenaming.org/), calls the use of language like this in software projects *inclusivity bugs*).
 
 Regardless of how common-place any manner of speaking or turn of phrase is or may have been for its time, the example demonstrates how the language we use can manifest bias and wind up excluding whole groups of people.
-To help skeptics empathize, imagine if instead of a crew of all white, Christian men the first mission to Mars is crewed by all black, Muslim women and the first to walk on Mars says something like *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
+To help skeptics empathize, imagine if instead of a crew of all white, Christian men as the first Apollo mission was (maybe all Apollo missions), the first mission to Mars is crewed by all black, Muslim women and the first to walk on Mars says something like *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
 
 As HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on another planet.
 Do we really need to worry so much about inclusive language?
 If we care about our project's reach and maximizing our ability to attract and retain collaborators, developers, users or sponsors, then yes we do.
 That is because the language we use has the power to welcome others in as well as push them away.
-Anyone who has been involved in writing proposals for a sponsor that is looking to fund work in a particular area of research understands the importance of and, indeed, already has a great deal of experience adjusting the *language* used to describe their work to fit the sponsor's call.
-In other words, we all can be quite mindful of the language we use when funding is on the line.
 
 Software projects involve a lot of communication.
 As developers, we write code, comments, documentation, research papers, presentations, job postings, promotional materials, discussion posts, emails, chats, tweets and more.
 It is now well known that language used in [job postings](https://www.mya.com/blog/unconscious-bias-in-job-descriptions/) has the effect of biasing the respondent pool in undesireable ways.
 The more we adopt inclusive language, the more we reduce biases and create welcoming and safe spaces for all participants to be their authentic selves, to be productive and to thrive.
 
+Any readers who have written proposals likely already appreciate the role language plays in communicating about our work.
+When writing proposals, we often struggle with and debate at length how individual word choices will have the effect of aligning our proposal with the sponsor's call.
+In other words, we all already appreciate the importance of and can be quite mindful of language when funding is on the line.
+Aiming to be inclusive in our language is no different.
+
 Inclusive *naming* is closely related to inclusive language but focuses primarily on the naming of things.
 That is the *names* we choose for abstract objects of our software systems.
-A callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
+A special callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
 Was Edmund Halley the first to observe and record [the comet](https://www.space.com/19878-halleys-comet.html) that bares his name?<sup>1</sup>
 Certainly not.
 Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Historical_comet_observations_in_China#Halley's_Comet) it almost 2,000 years earlier.
@@ -61,10 +66,9 @@ How might a neuro-diverse person feel about being tasked to add [*sanity checks*
 
 By the way, do readers recognize any bias manifested in the preceding questions?
 Its subtle but worth mentioning.
-The way these questions are worded suggest that only women would care about documentation that is laden with male pronouns or that only black people would care about language derived out of oppresive practices or that only neuro-diverse people would care about language associated with a state of mind.
+The way these questions are worded suggests that only women would care about documentation that is laden with male pronouns or that only black people would care about language derived out of racially oppresive practices or that only neuro-diverse people would care about language associated with a state of mind.
 The truth is, we all (*should*) care.
 And, to use language that suggests otherwise is, well, not inclusive.
-
 
 There is no way to phrase something that will be acceptable to literally *every* individual.
 And, there is no reason we should be aiming for that either.
@@ -73,21 +77,36 @@ The goal of inclusive language is to reduce the use of terms and phrases that wi
 It is not about being politically correct or being the language police.
 Its about being willing to acknowledge that certain terms and phrases (and, honestly, even names, icons and logos), however common in current culture, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
-Given the current social justice climate in which we all operate, some readers will feel that inclusive language efforts are nowhere near enough to meet the moment.
-Others will feel like such efforts are way too much.
-While we can acknowledge both prespectives, it is worth considering that [when we're accustomed to parroting the status quo, pausing to ponder more inclusive language can feel like oppression](https://www.huffpost.com/entry/when-youre-accustomed-to-privilege_b_9460662).
-
-Ever since adopting the practice myself, there isn't a week that goes by that I don't have the experience of questioning a term or phrase I am about to use.
-I often spend a few minutes searching the web to learn more about it.
-This includes terms and phrases I have used many times before without really thinking about it.
-We hope the resources we have compiled here are useful to any readers who may be similarly inclined.
-But, beware.
-In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
+Given the current social justice climate in which we all operate, some readers will feel that inclusive language efforts are nowhere near enough to meet the moment and are really a [distraction](https://www.wired.com/story/tech-confronts-use-labels-master-slave/) from bigger issues.
+Its hard to argue with that.
+Nonetheless, others will feel like such efforts are way too much.
+While we can acknowledge both prespectives, it is worth considering that [when we're accustomed to parroting the status quo, pausing to be more inclusive might feel like oppression](https://www.huffpost.com/entry/when-youre-accustomed-to-privilege_b_9460662).
 
 If you've read this far, you may be asking yourself, how do I get started?
 We suggest reading some of the resources listed here, especially [Plain Language](https://www.plainlanguage.gov/), [Google inclusive style](https://developers.google.com/style/inclusive-documentation), and [MicroSoft's Bias Free Communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication).
-In particular, if you are looking for *tooling* to help alert you to inclusive language issues ([Joanna Lee](https://github.com/joannalee333), a colleague on the [Inclusive Naming Initiative](https://inclusivenaming.org/), calls these *inclusivity bugs*) in your project, some of the resources listed here provide some on-line tooling.
-That said, DevOps-hardened tooling for inclusive language is still in its infancy stages.
+In particular, if you are looking for *tooling* to help alert you to inclusive language issues, some of the resources listed here provide tooling as a web service.
+That said, community standards and DevOps-hardened tooling for inclusive language is still in its infancy stages.
+
+Ever since adopting the practice myself, there isn't a week that goes by that I don't have the experience of questioning a term or phrase I am about to use.
+I often spend a few minutes searching the web to learn more about it.
+This includes terms and phrases I have used many times before without really thinking about it such as describing an off-topic enhancement request as having gone [*off the reservation*](https://www.npr.org/sections/codeswitch/2014/06/29/326690947/should-saying-someone-is-off-the-reservation-be-off-limits) or replying to it with [*no can do*](mentalfloss.com/article/625916/racist-origins-common-phrases) or introducing a colleague as a Python [*Guru*](https://www.yogajournal.com/lifestyle/cultural-appropriation/) or Java [*Ninja*](https://www.yogajournal.com/lifestyle/cultural-appropriation/), or complaining my bug reports are [*falling on deaf ears*](https://www.hearinglikeme.com/is-the-phrase-falling-on-deaf-ears-offensive/) or that the level of effort is too many [*man-hours*](https://bossbetty.com/big-story/manpower-man-hours-and-other-phrases-to-ix-nay-from-your-iased-bay-vocabulary/).
+
+We hope the resources we have compiled here are useful to any readers who may be similarly inclined.
+But, beware.
+In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://www.nytimes.com/1998/01/25/magazine/on-language-misrule-of-thumb.html) out there to sift through as well.
+In addition, when you are seeking to learn more about any possible negative impacts of a given word or phrase, its best to seek opinions from experts *within* the groups most likely impacted.
+In other words, if a given phrase has potential negative impacts against blacks, then language experts within the black community will likely have the the most informed guidance.
+If a given phrase has potential negative impacts against the deaf, then language experts within the deaf community will likely have the most informed guidance.
+
+Finally, in seeking to fix inclusivity bugs, its important to take care that we don't introduce another kind of problem...excluding the use of perfectly acceptable language for no other reason than out of fear of looking bad or being labeled non-inclusive.
+A good example is the word [*master*](https://www.etymonline.com/word/master) alone, apart from *slave*.
+Hopefully, we all can agree that [*master/slave*](https://www.wired.com/story/tech-confronts-use-labels-master-slave/) language is not acceptable.
+
+But, there is much less agreement, notably even within the black community, about the word *master* alone and with no relation to *slave*.
+There are many uses of *master* that have no historical roots in oppresive or genocidal systems.
+These include such terms as *mastermind*, *postmaster*, *master key*, *master recording*, achieving *mastery* of a skill and even common tech terms like *webmaster* and *scrum master*.
+This issue garnered much attention when GitHub [announced](https://www.vice.com/en/article/k7qbyv/github-to-remove-masterslave-terminology-from-its-platform) it would change its *default* branch name (which most users simply adopt without question) from *master* to *main*.
+While this was a welcome change, its worth pointing out that the *default* language of a widely used resource such as git represents a massive proliferation potential and is a qualitatively different situation than the choices individual projects make.
 
 <sup>1</sup>The comet is named for Halley because it is believed he was the first to have estimated its orbit and based on that connected recorded observations from 1531, 1607 and 1682 as being the same celestial object from which he correctly predicted its return in 1758.
 

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -66,7 +66,7 @@ Its about being willing to acknowledge that poorly chosen terms and phrases, how
 Ever since adopting the practice of being more inclusive in my own language, there isn't a week that goes by that I don't have the experience of questioning why I am about to write or speak a given phrase.
 I often spend a few minutes searching the web to learn more about it.
 This includes terms and phrases I have used many times before.
-We hope the resources we have compiled here are useful to any of our readers are are similarly inclined.
+We hope the resources we have compiled here are useful to any readers who may be similarly inclined.
 But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
 

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -17,45 +17,42 @@ Article title  | [Inclusive Naming Initiative](https://bssw.io/items/inclusive-n
 &nbsp; | [The Open Source Way](https://www.theopensourceway.org/)
 &nbsp; | [Google inclusive style](https://developers.google.com/style/inclusive-documentation)
 &nbsp; | [MicroSoft's Bias Free Communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication)
+&nbsp; | [Say This, Not That](https://thediversitymovement.com/say-this-not-that-a-guide-for-inclusive-language/)
+&nbsp; | [Effectively Naming Software Thingies](https://medium.com/@rabinovichsagi/effectively-naming-software-thingies-fcea9d78a699)
 Focus | Inclusive Practices
 
-When taking the first steps on the Moon, Armstrong said "This is a small step for a *man* but a giant leap for *man*kind."
-Later that same Moonwalk, he said..."It is a great honor...to be here representing...*men* of peaceable nations, *men* with an interest and a curiosity, and *men* with a vision for the future."
+When taking the first steps on the Moon, Armstrong said *"This is a small step for a **man** but a giant leap for **man**kind."*
+Later that same Moonwalk, he said, *"It is a great honor...to be here representing...**men** of peaceable nations, **men** with an interest and a curiosity, and **men** with a vision for the future."*
 
 Regardless of how common-place any given turn of phrase is or may have been for its time, the example demonstrates how the language we use can wind up excluding others.
-To help skeptics empathize, imagine if the first mission to Mars is a crew of all Black, Muslim women and the first to set foot on Mars says "This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."
+To help skeptics empathize, imagine if the first mission to Mars is a crew of all Black, Muslim women and the first to set foot on Mars says *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
 
 Ok, as HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on another planet.
 Do we really need to worry so much about inclusive language?
-If we care about maximizing our project's ability to attract and retain potential collaborators, developers, users and sponsors, then yes we do.
+If we care about maximizing our project's ability to attract and retain potential collaborators, developers, users or sponsors, then yes we do.
 That is because the language we use has the power to welcome others in as well as push them away.
 
 Software projects involve a lot of communication.
 As developers, we write code, comments, documentation, research papers, presentations, job postings, promotional materials, discussion posts, emails, chats, tweets and more.
-Just look at how much communication can be associated with a single [bug report](https://github.com/visit-dav/visit/issues/4908).
-
 It is now well known that language used in [job postings](https://www.mya.com/blog/unconscious-bias-in-job-descriptions/) has the effect of biasing the respondent pool in undesireable ways.
-The more we adopt inclusive language, the more we reduce biases and create welcoming and safe spaces for all stakeholders to bring their authentic selves to work and to thrive and be productive.
+The more we adopt inclusive language, the more we reduce biases and create welcoming and safe spaces for all stakeholders to be their authentic selves, to be productive and to thrive.
 
-While we recognize that there are sometimes no words that will be found acceptable to literally *every* individual, the goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally excluding whole groups of people.
+Sometimes, there are no words that will be acceptable to literally *every* individual.
+But, catering to specific individuals tastes or sensibilities is not what inclusive language is all about.
+The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally excluding whole groups of people.
 It is not about being politically correct or being the language police.
-Its about being willing to evaluate whether a given term or phrase is unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
+Its about being willing to acknowledge that poorly chosen terms and phrase can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
 Many terms and phrases we often use are simply unconcsiously repeating the words of others.
-That can be dangerous if one does not know either the meaning, context or history of the term.
+That can be dangerous if one is not mindful of either the meaning, context or history of the term.
 Do any readers know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
 
-A specific aspect of inclusive language in software involves the *naming* of things.
+Inclusive *naming* is closely associated with inclusive language and involves the naming of things.
 That is the *names* we choose for abstract objects of our software systems.
-There may be no other human activity that involves the naming of new things as much as software development.
-We tend to get particularly attached to names, often without any regard for whether the name is accurate reflection of function.
-
-More broadly, did you ever wonder whether Edmond Halley was indeed to first ever person to observe, record and ultimately predict the return of the comet that bares his name?
+We tend to get particularly attached to names, often without any regard for accuracy in source or function.
+Did you ever wonder whether Edmond Halley was indeed to first person to observe, record and ultimately predict the return of the comet that bares his name?
 What about Pythagoras' theorem?
 Was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous right-triangle rule, a2+b2=c2?
-
-There is power in naming and with great power, comes great responsibility.
-The names we use in our code and its associated artifacts (PR reviews, documentation, presentations, social media posts, etc.) are often shaped by our culture.
 
 New thinking cap. What does the practice look like. 
 

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -22,10 +22,10 @@ Article title  | [Inclusive Naming Initiative](https://bssw.io/items/inclusive-n
 Focus | Inclusive Practices
 
 When taking the first steps on the Moon, Armstrong said *"This is a small step for a **man** but a giant leap for **man**kind."*
-Later that same Moonwalk, he said, *"It is a great honor...to be here representing...**men** of peaceable nations, **men** with an interest and a curiosity, and **men** with a vision for the future."*
+Later that same Moonwalk, [he said](https://www.presidency.ucsb.edu/documents/telephone-conversation-with-the-apollo-11-astronauts-the-moon), *"It is a great honor...to be here representing...**men** of peaceable nations, **men** with an interest and a curiosity, and **men** with a vision for the future."*
 
-Regardless of how common-place any given turn of phrase is or may have been for its time, the example demonstrates how the language we use can wind up excluding others.
-To help skeptics empathize, imagine if the first mission to Mars is a crew of all Black, Muslim women and the first to set foot on Mars says *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
+Regardless of how common-place any given turn of phrase is or may have been for its time, the example demonstrates how the language we use can wind up excluding whole groups of people.
+To help skeptics empathize, imagine if the first mission to Mars is a crew of all Black, Muslim women and the first to set foot on Mars says something like *"This is a small step for a woman but a giant leap for woman-kind...Allahu Akbar."*
 
 Ok, as HPC/CSE software developers maybe we're not doing anything nearly as momentus as being the first Earthlings to walk on another planet.
 Do we really need to worry so much about inclusive language?
@@ -40,28 +40,34 @@ The more we adopt inclusive language, the more we reduce biases and create welco
 Inclusive *naming* is closely related to inclusive language and involves the naming of things.
 That is the *names* we choose for abstract objects of our software systems.
 A callenge with inclusive naming is that people tend to get pretty attached to names, often without any regard for accuracy, historical or otherwise.
-
+For example, was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous and fundamental right-triangle rule?
+There is plenty of [scholarly research](https://www.researchgate.net/publication/337941217_Mathematics_in_Ancient_Egypt_Part_II) that suggests he was not.
+<!---
 Do you know why we call it "Halley's Comet"?
 Halley was not the first to observe or even record it.
 Chinese astronomers [observed and recorded](https://en.wikipedia.org/wiki/Historical_comet_observations_in_China#Halley's_Comet) it almost 2,000 years before Halley.
 Halley, however, is believed to be the first to estimate its orbit and based on that estimation connect recorded observations from 1531, 1607 and 1682 as being the same object and then correctly predict its return in 1758.
+-->
 
-What about Pythagoras' theorem?
-Was Pythagoras indeed the [first person](https://en.wikipedia.org/wiki/Pythagoras#In_mathematics) ever to write down that famous and fundamental right-triangle rule?
-Much [scholarly research](https://www.researchgate.net/publication/337941217_Mathematics_in_Ancient_Egypt_Part_II) suggests he was not.
+Many terms and phrases we often use are simply unconcsiously following precedent set by others before us.
+That can be dangerous if one is not mindful of either the meaning, history or impact of the term upon others.
+Do any readers know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
+How might a women feel reading documentation that constantly refers to the user as [*he*, *his* or *him*](https://www.washingtonpost.com/world/2019/12/15/guide-how-gender-neutral-language-is-developing-around-world/)?
+How might a black person feel reading that existing users will be [*grandfathered in*](https://www.npr.org/sections/codeswitch/2013/10/21/239081586/the-racial-history-of-the-grandfather-clause) when the software license terms are changed?
+How might a neuro-diverse person feel about being tasked to add [*sanity checks*](https://gist.github.com/seanmhanson/fe370c2d8bd2b3228680e38899baf5cc) to a software package's test suite?
 
 Sometimes, there is no way to phrase something that will be acceptable to literally *every* individual.
-But, catering to any specific individual's tastes and sensibilities is not what inclusive language is all about.
+Nor, should we aim for that.
+Catering to any specific individual's tastes and sensibilities is not what inclusive language is all about.
 The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally *excluding whole groups* of people.
 It is not about being politically correct or being the language police.
-Its about being willing to acknowledge that poorly chosen terms and phrases, even if part of common vernacular, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
-
-Many terms and phrases we often use are simply unconcsiously repeating the words of others.
-That can be dangerous if one is not mindful of either the meaning, context or history of the term.
-Do any readers know why we call defects in software [*bugs*](https://en.wikipedia.org/wiki/Software_bug#History)?
+Its about being willing to acknowledge that poorly chosen terms and phrases, however common in current vernacular, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
 
 Ever since adopting the practice of being more inclusive in my own language, there isn't a week that goes by that I don't have the experience of questioning myself about why I am about to write or speak a given phrase.
-I often spend a few minutes searching the web to learn more about it before I move ahead as planned to select different words.
+I often spend a few minutes searching the web to learn more about it before I choose to either move ahead as planned or select different words.
+We hope the resources we have compiled here are useful to anyone who is similarly inclined.
+But, beware.
+In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
 
 <!--
 https://www.cfr.org/blog/woman-moon-and-equality-earth

--- a/CuratedContent/InclusiveLanguageResources.md
+++ b/CuratedContent/InclusiveLanguageResources.md
@@ -63,16 +63,18 @@ The way these questions are worded suggest that only women would care about docu
 The truth is, we all (*should*) care.
 And, to use language that suggests otherwise is, well, not inclusive.
 
+
 There is no way to phrase something that will be acceptable to literally *every* individual.
 And, there is no reason we should be aiming for that either.
 Catering to any one individual's tastes and sensibilities is not what inclusive language is all about.
 The goal of inclusive language is to reduce the use of terms and phrases that wind up uniformally *excluding whole groups* of people.
 It is not about being politically correct or being the language police.
 Its about being willing to acknowledge that certain terms and phrases (and, honestly, even names, icons and logos), however common in current culture, can be unnecessarily exclusive and being willing to consider and adopt alternatives that are less so.
+Anyone who has been involved in writing proposals for a sponsor that is looking to fund work in a particular area of research understands the importance of and already has a great deal of experience adjusting the *language* used to describe their work to fit the sponsor's call.
 
 Given the current social justice climate in which we all operate, some readers will feel that inclusive language efforts are nowhere near enough to meet the moment.
 Others will feel like such efforts are way too much.
-While we can acknowledge both prespectives, it is worth considering that when we're accustomed to parroting the status quo, striving for more inclusive language can feel like oppression.
+While we can acknowledge both prespectives, it is worth considering that [when we're accustomed to parroting the status quo, ponder more inclusive language can feel like oppression](https://www.huffpost.com/entry/when-youre-accustomed-to-privilege_b_9460662).
 
 Ever since adopting the practice myself, there isn't a week that goes by that I don't have the experience of questioning a term or phrase I am about to use.
 I often spend a few minutes searching the web to learn more about it.
@@ -82,9 +84,9 @@ But, beware.
 In seeking greater understanding of the history of terms and phrases you thought you knew, there is a lot of [misinformation](https://en.wikipedia.org/wiki/Rule_of_thumb) out there to sift through as well.
 
 If you've read this far, you may be asking yourself, how do I get started?
-I would suggest reading some of the resources offered here, especially [Plain Language](https://www.plainlanguage.gov/), [Google inclusive style](https://developers.google.com/style/inclusive-documentation), and [MicroSoft's Bias Free Communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication).
-In particular, if you are looking for *tooling* to help find and correct inclusive language issues ([Joanna Lee](https://github.com/joannalee333), a colleague on the [Inclusive Naming Initiative](https://inclusivenaming.org/), calls these *inclusivity bugs*) in your project, some of the resources listed here provide some tooling.
-That said, DevOps level tooling for inclusive language is still in its infancy stages.
+We suggest reading some of the resources listed here, especially [Plain Language](https://www.plainlanguage.gov/), [Google inclusive style](https://developers.google.com/style/inclusive-documentation), and [MicroSoft's Bias Free Communication](https://docs.microsoft.com/en-us/style-guide/bias-free-communication).
+In particular, if you are looking for *tooling* to help alert you to inclusive language issues ([Joanna Lee](https://github.com/joannalee333), a colleague on the [Inclusive Naming Initiative](https://inclusivenaming.org/), calls these *inclusivity bugs*) in your project, some of the resources listed here provide some on-line tooling.
+That said, DevOps-hardened tooling for inclusive language is still in its infancy stages.
 
 <sup>1</sup>The comet is named for Halley because it is believed he was the first to have estimated its orbit and based on that connected recorded observations from 1531, 1607 and 1682 as being the same celestial object from which he correctly predicted its return in 1758.
 

--- a/utils/wikize_refs.py
+++ b/utils/wikize_refs.py
@@ -36,6 +36,11 @@ document. Items in the list of references link off-page to their
 intended destinations. The resulting file is still GitHub flavored
 Markdown with a minimal amount of embedded HTML.
 
+To create just simple, ordinary footnotes (e.g. not reference style
+links) using the same machinery, ensure the URL portion of the
+reference link is just the hashtag/pound character ('#') and then
+enclose the footnote text in double quotes.
+
 If the file contains no footnotes, it will be left unchanged.
 Some minimal error checks include: a) there is an existing link
 definition for every footnote and b) every link definition appears
@@ -604,10 +609,16 @@ def build_reference_list_lines(remapped_ref_map, renumber, twocol):
                 else:
                     outlines.append("* <a name=\"%s-%s\"></a><sup>%s</sup>[%s<br>%s](%s)\n"%(magic(), v3, v3, v[1], v[2], v[0]))
             elif v[1]: # only title exists
-                if twocol:
-                    outlines.append("<sup>%s</sup><a name=\"%s-%s\" href=\"%s\">%s</a>\n"%(v3, magic(), v3, v[0], v[1]))
+                if v[0] == '#':
+                    if twocol:
+                        outlines.append("<sup>%s</sup><a name=\"%s-%s\"></a>%s\n"%(v3, magic(), v3, v[1]))
+                    else:
+                        outlines.append("* <a name=\"%s-%s\"></a><sup>%s</sup>%s\n"%(magic(), v3, v3, v[1]))
                 else:
-                    outlines.append("* <a name=\"%s-%s\"></a><sup>%s</sup>[%s](%s)\n"%(magic(), v3, v3, v[1], v[0]))
+                    if twocol:
+                        outlines.append("<sup>%s</sup><a name=\"%s-%s\" href=\"%s\">%s</a>\n"%(v3, magic(), v3, v[0], v[1]))
+                    else:
+                        outlines.append("* <a name=\"%s-%s\"></a><sup>%s</sup>[%s](%s)\n"%(magic(), v3, v3, v[1], v[0]))
             elif v[2]: # only bibinfo exists
                 if twocol:
                     outlines.append("<sup>%s</sup><a name=\"%s-%s\" href=\"%s\">%s</a>\n"%(v3, magic(), v3, v[0], v[2]))


### PR DESCRIPTION
# Description

Resolves #1122

The `wikize_refs.py` tool uses html superscripting combined with GFM reference style links to do Wikepedia-like linking. 

But, that machinery can then prevent an author from using html superscripting to do ordinary footnoting in a compatible way.

This update fixes that as per comments in 

* [x] Set list of Reviewers (at least one).
* [x] Add to Project [BSSw Internal].
* ~~[ ] View the modified `*.md` files as rendered in GitHub.~~
* ~~[ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.~~
* ~~[ ] Watch for PR check failures.~~
* [ ] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [ ] Ensure at least one reviewer signs off on the changes.
* [ ] Once reviewer has approved and PR check pass, then merge the PR.


<!-- Standard links below, leave these this section! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
