### PR TITLE
Add ordinary footnoting to wikize_refs.py

### DIFF
--- a/utils/wikize_refs.py
+++ b/utils/wikize_refs.py
@@ -36,6 +36,11 @@ document. Items in the list of references link off-page to their
 intended destinations. The resulting file is still GitHub flavored
 Markdown with a minimal amount of embedded HTML.
 
+To create just simple, ordinary footnotes (e.g. not reference style
+links) using the same machinery, ensure the URL portion of the
+reference link is just the hashtag/pound character ('#') and then
+enclose the footnote text in double quotes.
+
 If the file contains no footnotes, it will be left unchanged.
 Some minimal error checks include: a) there is an existing link
 definition for every footnote and b) every link definition appears
@@ -604,10 +609,16 @@ def build_reference_list_lines(remapped_ref_map, renumber, twocol):
                 else:
                     outlines.append("* <a name=\"%s-%s\"></a><sup>%s</sup>[%s<br>%s](%s)\n"%(magic(), v3, v3, v[1], v[2], v[0]))
             elif v[1]: # only title exists
-                if twocol:
-                    outlines.append("<sup>%s</sup><a name=\"%s-%s\" href=\"%s\">%s</a>\n"%(v3, magic(), v3, v[0], v[1]))
+                if v[0] == '#':
+                    if twocol:
+                        outlines.append("<sup>%s</sup><a name=\"%s-%s\"></a>%s\n"%(v3, magic(), v3, v[1]))
+                    else:
+                        outlines.append("* <a name=\"%s-%s\"></a><sup>%s</sup>%s\n"%(magic(), v3, v3, v[1]))
                 else:
-                    outlines.append("* <a name=\"%s-%s\"></a><sup>%s</sup>[%s](%s)\n"%(magic(), v3, v3, v[1], v[0]))
+                    if twocol:
+                        outlines.append("<sup>%s</sup><a name=\"%s-%s\" href=\"%s\">%s</a>\n"%(v3, magic(), v3, v[0], v[1]))
+                    else:
+                        outlines.append("* <a name=\"%s-%s\"></a><sup>%s</sup>[%s](%s)\n"%(magic(), v3, v3, v[1], v[0]))
             elif v[2]: # only bibinfo exists
                 if twocol:
                     outlines.append("<sup>%s</sup><a name=\"%s-%s\" href=\"%s\">%s</a>\n"%(v3, magic(), v3, v[0], v[2]))


### PR DESCRIPTION
Resolves #1122

The `wikize_refs.py` tool uses html superscripting combined with GFM reference style links to do Wikepedia-like citations.

But, that machinery can then prevent an author from using html superscripting to do ordinary footnoting in a compatible way or perhaps mislead an author into using this machinery for ordinary footnotes. Either way, enhancing `wikize_refs.py` to deal better with ordinary footnotes made a lot of sense.

This update fixes that as per comments in #1122 with the exception that the footnote remains *in-line* with other off-page-linking citations.

## PR checklist for (internal) files not displayed on bssw.io site

*Click "Write" above and remove comment markers to see below checklist items*

* [x] Set list of Reviewers (at least one).
* [x] Add to Project [BSSw Internal].
* ~~[ ] View the modified `*.md` files as rendered in GitHub.~~
* ~~[ ] If changes are to the GitHub pages site under the `docs/` directory, consider viewing locally with Jekyll.~~
* ~~[ ] Watch for PR check failures.~~
* [ ] Make any final changes to the PR based on feedback and review GitHub (and Jekyll) rendered files.
* [ ] Ensure at least one reviewer signs off on the changes.
* [ ] Once reviewer has approved and PR check pass, then merge the PR.


<!-- Standard links below, leave these this section! -->

[preview]: https://preview.bssw.io
[bssw.io]: https://bssw.io
[Content Development]: https://github.com/betterscientificsoftware/bssw.io/projects/3
[BSSw Internal]: https://github.com/betterscientificsoftware/bssw.io/projects/2
[meta-data]: https://betterscientificsoftware.github.io/bssw.io/bssw_styling_common.html#metadata-section
[wikize_refs.py]: https://github.com/betterscientificsoftware/bssw.io/blob/master/utils/README.md#wikize_refspy
