### PR TITLE
Add note regarding three-dash xml comments

### DIFF
--- a/docs/pages/bssw/bssw_content_metadata.md
+++ b/docs/pages/bssw/bssw_content_metadata.md
@@ -23,6 +23,9 @@ RSS update: 2020-12-17
 
 Please note above:
 * The use of `<!--- --->` surrounding the metadata.
+  * **Note:** Do not confuse these as *just* XML comments.
+    Indeed, they *are* XML comments but the third dash is necessary.
+    Three dashes are used to distingish this block as bssw.io metadata.
 * Each metadata parameter is on a separate line.
 * Please follow the rules of use colon and commas as specified above. Letter case does not matter.
 


### PR DESCRIPTION
Resolves #912

Capture information about the use of three-dash xml comments `<!---` and `--->` so readers understand its intentional and necessary and not a mistake for *ordinary* XML comments.