### PR TITLE
Revert "skip ci on forks"

### DIFF
--- a/.github/workflows/merge-pr-to-preview.yml
+++ b/.github/workflows/merge-pr-to-preview.yml
@@ -7,9 +7,7 @@ on:
       - master
 jobs:
   sync-pull-request:
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'preview') &&
-      github.repository_owner == 'betterscientificsoftware'
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
CC: @markcmiller86, @bernhold, @rinkug 

This reverts commit c5f4a05c395d3395fe99674cd92e120f91865374.

We need to be able to merge to 'preview' from PRs created from a fork.  That is the only way that external contributors can propose new contributions.
