### PR TITLE
Dealing with SC23's bad behavior

### DIFF
--- a/Events/2023-11-sc23-sw-events.md
+++ b/Events/2023-11-sc23-sw-events.md
@@ -17,19 +17,19 @@ The Supercomputing conference series is one of the premier venues for high-perfo
 
 Day/Time<br>(MST time zone) | Event Type | Event Title (see linked program page for full details)
 :---     |    :------ |--------------------------------------------------------
-Sun., Nov. 12<br>8:30am-5:00pm | Tutorial | [Better Software for Reproducible Science](https://sc23.supercomputing.org/?post_type=page&p=3479&id=tut147&sess=sess225)
-Sun., Nov. 12<br>8:30am-5:00pm| Tutorial | [Managing HPC Software Complexity with Spack](https://sc23.supercomputing.org/?post_type=page&p=3479&id=tut162&sess=sess226)
-Sun., Nov. 12<br>9:00am-12:30pm | Workshop | [Research Software Engineers in HPC (RSE-HPC-2023)](https://sc23.supercomputing.org/?post_type=page&p=3480&sess=sess418)
-Sun., Nov. 12<br>1:30pm-5:00pm | Tutorial | [Secure Coding Practices and Dependency Analysis Tools](https://sc23.supercomputing.org/?post_type=page&p=3479&id=tut105&sess=sess215)
-Sun., Nov. 12<br>2:00pm-5:30pm | Workshop | [7th International Workshop on Software Correctness for HPC Applications (Correctness '23)](https://sc23.supercomputing.org/?post_type=page&p=3479&id=wksp120&sess=sess119)
-Mon., Nov. 13<br>9:00am-12:30pm | Workshop | [2023 International Workshop on Performance, Portability, and Productivity in HPC (P3HPC)](https://sc23.supercomputing.org/?post_type=page&p=3480&sess=sess441)
-Mon., Nov. 13<br>9:00am-12:30pm | Workshop | [AI Assisted Software Development for HPC (AI4DEV)](https://sc23.supercomputing.org/?post_type=page&p=3480&sess=sess443)
-Tue., Nov. 14<br>10:30am-12:00pm | Panel | [RSEs in HPC Centers: Funding, Coordinating, Doing](https://sc23.supercomputing.org/?post_type=page&p=3479&id=pan101&sess=sess186)
-Wed., Nov. 15<br>12:15pm-1:15pm | BoF | [Navigating Complexity: Achieving Performance Portability in the Evolving Landscape of Heterogeneous HPC Systems](https://sc23.supercomputing.org/?post_type=page&p=3479&id=bof170&sess=sess345)
-Wed., Nov. 15<br>12:15pm-1:15pm | BoF | [Software Testing for Scientific Computing in HPC](https://sc23.supercomputing.org/?post_type=page&p=3479&id=bof189&sess=sess383)
-Wed., Nov. 15<br>1:30pm-3:00pm | Inclusivity | [Fostering Inclusivity in Research Computing and Data: Case Studies, Best Practices, and Scaling Strategies](https://sc23.supercomputing.org/presentation/?id=misc292&sess=sess486)
-Wed., Nov. 15<br>5:15pm-6:45pm | BOF | [Scientific Software and the People Who Make It Happen: Building Communities of Practice](https://sc23.supercomputing.org/?post_type=page&p=3479&id=bof177&sess=sess375)
-Thu1., Nov. 16<br>12:15pm-1:15pm | BOF | [Spack Community BoF](https://sc23.supercomputing.org/?post_type=page&p=3479&id=bof196&sess=sess346)
+Sun., Nov. 12<br>8:30am-5:00pm | Tutorial | [Better Software for Reproducible Science](https://sc23.conference-program.com/presentation/?id=tut147&sess=sess225)
+Sun., Nov. 12<br>8:30am-5:00pm| Tutorial | [Managing HPC Software Complexity with Spack](https://sc23.conference-program.com/presentation/?id=tut162&sess=sess226)
+Sun., Nov. 12<br>9:00am-12:30pm | Workshop | [Research Software Engineers in HPC (RSE-HPC-2023)](https://sc23.conference-program.com/session/?sess=sess418)
+Sun., Nov. 12<br>1:30pm-5:00pm | Tutorial | [Secure Coding Practices and Dependency Analysis Tools](https://sc23.conference-program.com/presentation/?id=tut105&sess=sess215)
+Sun., Nov. 12<br>2:00pm-5:30pm | Workshop | [7th International Workshop on Software Correctness for HPC Applications (Correctness '23)](https://sc23.conference-program.com/session/?sess=sess438)
+Mon., Nov. 13<br>9:00am-12:30pm | Workshop | [2023 International Workshop on Performance, Portability, and Productivity in HPC (P3HPC)](https://sc23.conference-program.com/session/?sess=sess441)
+Mon., Nov. 13<br>9:00am-12:30pm | Workshop | [AI Assisted Software Development for HPC (AI4DEV)](https://sc23.conference-program.com/session/?sess=sess443)
+Tue., Nov. 14<br>10:30am-12:00pm | Panel | [RSEs in HPC Centers: Funding, Coordinating, Doing](https://sc23.conference-program.com/presentation/?id=pan101&sess=sess186)
+Wed., Nov. 15<br>12:15pm-1:15pm | BoF | [Navigating Complexity: Achieving Performance Portability in the Evolving Landscape of Heterogeneous HPC Systems](https://sc23.conference-program.com/presentation/?id=bof170&sess=sess345)
+Wed., Nov. 15<br>12:15pm-1:15pm | BoF | [Software Testing for Scientific Computing in HPC](https://sc23.conference-program.com/presentation/?id=bof189&sess=sess383)
+Wed., Nov. 15<br>1:30pm-3:00pm | Inclusivity | [Fostering Inclusivity in Research Computing and Data: Case Studies, Best Practices, and Scaling Strategies](https://sc23.conference-program.com/presentation/?id=misc292&sess=sess486)
+Wed., Nov. 15<br>5:15pm-6:45pm | BOF | [Scientific Software and the People Who Make It Happen: Building Communities of Practice](https://sc23.conference-program.com/presentation/?id=bof177&sess=sess375)
+Thu1., Nov. 16<br>12:15pm-1:15pm | BOF | [Spack Community BoF](https://sc23.conference-program.com/presentation/?id=bof196&sess=sess346)
 
 <!---
 Publish: yes


### PR DESCRIPTION
For some reason, SC23 changed nearly all of the URLs to events in their online program.  And apparently they're not putting in redirects. And the mapping is not simple.  So I just had to spend an hour redoing the links on this event.  :annoyed face:

By making a submission here, you agree to [BSSw.io content licensing terms](https://github.com/betterscientificsoftware/bssw.io/blob/main/TERMS.md).

You are welcome to submit an *idea* for an article or a completed article.

After your submission is recieved, it will be reviewed by the BSSw.io editorial staff and we will be in touch with you.

If BSSw.io editorial staff decide to move your submission forward, a [checklist](https://betterscientificsoftware.github.io/bssw.io/bssw_content_pr_checklist.html) of additional actions to take to complete the publication process may be pasted here.
