### PR TITLE
Add CI for wikize refs

### DIFF
--- a/.github/workflows/wikize-refs-ci.yml
+++ b/.github/workflows/wikize-refs-ci.yml
@@ -1,0 +1,29 @@
+name: Wikize Refs Check
+
+on:
+  pull_request:
+    branches: [ main ]
+  paths:
+    - '**.md'
+    - '!docs/**'
+
+jobs:
+  wikize-refs-source:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Run wikize-refs on each file
+        run: |
+          set -e
+          files=$(git diff --name-only ${{ github.event.before }} ${{ github.event.after }})
+          for file in $files; do
+            wikize-refs.py -u "$file"
+          done


### PR DESCRIPTION
Resolves #729

This is a workflow to run `wikize-refs.py` on any `.md` file in the PR not in `docs` subfolder.

Running `wikize-refs.py` on a non-wikized file is harmless and will return 0 status.
Running `wikize-refs.py` on a wikized file will prodoce non-zero status if it would change the file.
