### PR TITLE
fix error in filename and url

### DIFF
--- a/Events/hpcbp-086-softwaresustainability.md
+++ b/Events/hpcbp-086-softwaresustainability.md
@@ -19,7 +19,7 @@ Resource Information | Details
 Webinar Title | Kitware Software Sustainability Matrix
 Date and Time | 2024-08-07 1:00 pm - 2:00 pm EDT
 Presenters | Bill Hoffman (Kitware, Inc.), and Will Schroeder (Kitware, Inc.)
-Registration, Information, and Archives | 	<https://ideas-productivity.org/events/hpcbp-0086-softwaresustainability>
+Registration, Information, and Archives | 	<https://ideas-productivity.org/events/hpcbp-086-softwaresustainability>
 Presentation Language | English	   
 
 **Webinars are free and open to the public, but advance registration is required through the Event website. Archives (recording, slides, Q&A) will be posted at the same link soon after the event, and all registrants will be notified.**


### PR DESCRIPTION
The event file on the i-p.o site had an extra zero in the filename, which affected both the URL for the event on the i-p.o site that the name of the file generated for the bssw.io version of the event.

By making a submission here, you agree to [BSSw.io content licensing terms](https://github.com/betterscientificsoftware/bssw.io/blob/main/TERMS.md).

You are welcome to submit an *idea* for an article or a completed article.

After your submission is received, it will be reviewed by the BSSw.io editorial staff and we will be in touch with you.

If BSSw.io editorial staff decide to move your submission forward, a [checklist](https://betterscientificsoftware.github.io/bssw.io/bssw_content_pr_checklist.html) of additional actions to take to complete the publication process may be pasted here.
