### PR TITLE
Add 2025 INTERSECT Bootcamp Event

### DIFF
--- a/Events/2025-07-intersect-bootcamp.md
+++ b/Events/2025-07-intersect-bootcamp.md
@@ -1,0 +1,71 @@
+# INTERSECT Bootcamp '25
+
+<!-- deck text start -->
+The INTERSECT Research Software Engineering Bootcamp will be a 4.5 day intensive hands-on workshop focusing on practices that will help research software developers improve the quality, reproducibility, and sustainability of their software.
+<!-- deck text ends -->
+
+- Application Deadline: March 28, 2025
+- Event Dates: July 14-18, 2025
+- Location: Princeton, New Jersey
+- Website: https://intersect-training.org/bootcamp25/
+- Organizers: INTERSECT Project
+
+#### Contributed by [Ian A. Cosden](https://github.com/cosden/)
+
+#### Publication date: February 20, 2025
+
+Event Information | Details
+:--- | :---			   
+Event Name | [INTERSECT Bootcamp '25](https://intersect-training.org/bootcamp25/)
+Application Deadline | March 28, 2025
+Event Dates | July 14-18, 2025
+Website | https://intersect-training.org/bootcamp25/
+
+The INTERSECT Research Software Engineering Bootcamp will be a 4.5 day intensive hands-on workshop focusing on practices that will help research software developers improve the quality, reproducibility, and sustainability of their software.
+
+### Target Audience
+
+The bootcamp is primarily geared towards those who self-identify as intermediate research software developers with backgrounds in a research domain other than computer science. This includes graduate students, postdoctoral researchers, early career professionals, and many others. The ideal participants are those who, after some hands-on experience writing code, are looking for more software development training to either prepare them for a career writing research software or to be a more efficient developer. In either case, attendees should have a strong interest in developing research software in the future.
+
+We expect attendees to come with a basic background in programming. Previous, formal computer science (CS) training is specifically not a prerequisite. Rather, we expect many, if not most attendees to be self-taught programmers coming from non-CS domains. Where possible, we will aim to keep instruction uncoupled from specific languages or technologies. Because this is nearly impossible, we expect attendees to have a working knowledge of python, basic git commands and functionality, competency with an editor, and experience working with the command line. Additionally, participants should be comfortable managing their own development environment on their laptop.
+
+Our INTERSECT [learner profiles](https://intersect-training.org/learner-profiles/) provide examples of the types of people for whom this workshop is appropriate. However, we welcome anyone who fits the description above to submit an application for the Bootcamp.
+
+### Topics/Agenda
+
+The bootcamp will run approximately 8:30-4 Monday through Thursday and 8:30-12:00 on Friday. Because of the intensity of the work, we expect to have a break one afternoon midweek.
+
+The bootcamp will focus on the following topics:
+
+- Software Design
+- Collaborative git
+- Pull requests
+- Code review
+- Licensing
+- Documentation
+- Testing
+- CI/CD
+- Packaging & Distribution
+
+Each session will include some lecture but most sessions will include hands-on activities and exercises, including some opportunities to work in groups. Participants will be expected to bring their own laptop.
+
+Participants are expected to attend the entirety of the bootcamp. Failure to do so may result in a forfeiture of all or part of a travel grant.
+
+### Cost & Funding
+
+The INTERSECT project, through a grant from the National Science Foundation, has funding to cover the food, travel, and lodging expenses for up to 30 attendees as a travel grant. This travel grant includes 5 nights of hotel plus up to $800 for transportation and food (reimbursed via Princeton University or the University of Alabama). In addition to those funded directly by the INTERSECT project, we will accept self-funded participants as space allows.
+
+During the workshop we will provide breakfast and lunch (M-F) for all participants (whether supported by INTERSECT or paying their own way). 
+
+### Eligibility
+
+We welcome anyone who identifies with the description above and is interested in improving their software development skills. Participants must be affiliated with a US institution.
+
+Selection Criteria: Potential participants will be asked to explain their background and future goals as they relate to research software. Applicants are encouraged to use the questions and space provided in the application to make a strong argument for why their application should be accepted. Applications will be reviewed independent of need for funding until all available funded slots are filled after which those applicants who are able to support their own travel will be accepted until all slots are filled.
+
+Please check the [bootcamp webpage](https://intersect-training.org/bootcamp25/) for further details and updates.
+
+<!---
+Publish: yes
+Topics: in-person learning, software engineering, design, strategies for more effective teams, testing, continuous integration testing, release and deployment
+--->


### PR DESCRIPTION
This adds an event page for the 2025 INTERSECT Research Software Engineering Bootcamp. Applications are open until the end of March for the mid-July event. 

Thanks to David's suggestion I used last year's event page as a template (https://github.com/betterscientificsoftware/bssw.io/blob/main/Events/2024-07-intersect-bootcamp.md) however I don't know how you want to treat the publication date or the footer elements. Feel free to edit/adjust as needed. 