### PR TITLE
Adding another ignore word to codespell

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -4,5 +4,5 @@ check-hidden =
 # Disable warnings about binary files
 quiet-level = 2
 # Ignore Words List: Formal names, acronyms, other words
-ignore-words-list = nam,hass,hart,wil,damon,leary,cruzes,nwo,idaes,precice,rcall,ags,coo,theses,nd,ba,algebraical,unsecure,commun,ore,re-use,strack
+ignore-words-list = nam,hass,hart,wil,damon,leary,cruzes,nwo,idaes,precice,rcall,ags,coo,theses,nd,ba,algebraical,unsecure,commun,ore,re-use,strack,Rollin
 skip = */.git,*/*.pdf,*/_config.yml,*/jquery.shuffle.min.js,*/build_tests/*,*/utils/tests/*.md


### PR DESCRIPTION
In response to (recent?) complaints from the codespell action.

> ./Events/hpcbp-008-python.md:40: Rollin ==> Rolling, Roll in
> ./Events/hpcbp-008-python.md:85: Rollin ==> Rolling, Roll in

This refers to one of the presenters, Rollin Thomas.
