### PR TITLE
Add event announcement for the R3Sw tutorial

### DIFF
--- a/Events/2025-11-tutorial-r3sw.md
+++ b/Events/2025-11-tutorial-r3sw.md
@@ -1,0 +1,76 @@
+# Tutorial: Rigor and Reasoning in Research Software (R3Sw)
+
+- Event Date: November 5-7, 2026
+- Location: Boulder, CO and online
+- Website: https://ncar.github.io/correctness-workshop/
+- Organizers: Alper Altuntas, Allison Baker
+
+#### Contributed by: [Alper Altuntas](https://github.com/alperaltuntas)
+
+#### Publication date: October 8, 2025
+
+<!-- deck text start -->
+The Rigor and Reasoning in Research Software (R3Sw) tutorial will introduce practical techniques to make scientific software more reliable, understandable, and trustworthy, without losing the creativity and speed that drive research.
+Through hands-on exercises, participants will learn to transform research code into modular, testable, and verifiable software, exploring a “ladder of rigor” that spans techniques such as unit testing, property-based testing, and theorem proving.
+<!-- deck text ends -->
+
+Event Information | Details
+:--- | :---
+Event Name | [Tutorial on Rigor and Reasoning in Research Software (R3Sw)](https://ncar.github.io/correctness-workshop/)
+Registration deadline | October 31, 2025
+Event Date | November 5-7, 2026
+Website | https://ncar.github.io/correctness-workshop/
+
+
+### Summary
+
+The R3Sw tutorial offers a practical and accessible approach to building reliable, maintainable,
+and trustworthy research software through thoughtful design, systematic testing, and automated
+reasoning, while preserving the creativity and speed essential to research.
+
+Participants will learn to reason about code the same way they reason about science: by forming hypotheses, testing them, and refining their understanding and designs through evidence.
+
+Key topics include:
+
+ - Designing for robustness with specifications
+ - Unit testing with `pytest` as a foundation for confidence
+ - Property-based testing with `Hypothesis` to explore edge cases automatically 
+ - Theorem proving with `Z3` for reasoning about code with mathematical precision
+
+The program also includes a session on *verifiable and explainable AI/ML* featuring invited speakers from academia and industry, and a panel discussion.
+
+The tutorial welcomes scientists, software engineers, and students from any domain who seek to strengthen the rigor and reliability of their research software. Familiarity with Python is required, but no prior experience with testing or verification is necessary.
+
+The tutorial will be held at the Mesa Laboratory of the NSF National Center for Atmospheric Research (NCAR) in Boulder, Colorado, from November 5–7, 2025, with both in-person and remote participation options available.
+
+This event is sponsored by the 2025 Better Scientific Software (BSSw) Fellowship program
+and is held in conjunction with the [2nd Workshop on Correctness and Reproducibility for Earth System Software](https://ncar.github.io/correctness-workshop/).
+
+### Tutorial Lead:
+
+ - Alper Altuntas (NSF NCAR)
+
+### Guest Lecturers and Invited Speakers
+
+ - Soonho Kong (AWS)
+ - Philip Zucker (Draper)
+ - Adrianna Foster (NSF NCAR)
+ - Antonios Mamalakis (UVA)
+ - Deepak Cherian (Earthmover)
+
+### Program Committee 
+
+ - Allison Baker (NSF NCAR), co-chair
+ - John Baugh (NCSU)
+ - Ilene Carpenter (HPE)
+ - Brian Dobbins (NSF NCAR)
+ - Michael Duda (NSF NCAR)
+ - Karsten Peters-von Gehlen (DKRZ)
+ - Ganesh Gopalakrishnan (Utah)
+ - Dorit Hammerling (Mines)
+ - Balwinder Singh (PNNL)
+
+<!---
+Publish: yes
+Topics: conferences and workshops, Research Software Engineers
+--->


### PR DESCRIPTION
This PR adds an event announcement for the upcoming Rigor and Reasoning in Research Software (R3Sw) tutorial  (November 5-7), sponsored by the BSSw Fellowship program.